### PR TITLE
Fix AsyncIterator.prototype.flatMap to flatMap async iterables

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -587,18 +587,20 @@ contributors: Gus Caplan
             1. If ? IteratorComplete(_next_) is *true*, return *undefined*.
             1. Let _value_ be ? IteratorValue(_next_).
             1. Let _mapped_ be ? Await(? Call(_mapper_, *undefined*, &laquo; _value_ &raquo;)).
-            1. Let _usingIterator_ be ? Get(_mapped_, @@iterator).
+            1. Let _usingIterator_ be ? Get(_mapped_, @@asyncIterator).
             1. If _usingIterator_ is *undefined*, then
-              1. Perform ? Yield(_mapped_).
-            1. Else,
-              1. Let _innerIterator_ be ? GetIterator(_mapped_, ~sync~, _usingIterator_).
-              1. Let _innerAlive_ be *true*.
-              1. Repeat, while _innerAlive_ is *true*,
-                1. Let _innerNext_ be ? Await(? IteratorNext(_innerIterator_)).
-                1. If ? IteratorComplete(_nextNext_) is *true*, set _innerAlive_ to *false*.
-                1. Else,
-                  1. Let _innerValue_ be ? IteratorValue(_innerNext_).
-                  1. Perform ? Yield(_innerValue_).
+              1. Let _usingIterator_ be ? Get(_mapped_, @@iterator).
+              1. If _usingIterator_ is *undefined*, then
+                1. Perform ? Yield(_mapped_).
+              1. Else,
+                1. Let _innerIterator_ be ? GetIterator(_mapped_, ~sync~, _usingIterator_).
+                1. Let _innerAlive_ be *true*.
+                1. Repeat, while _innerAlive_ is *true*,
+                  1. Let _innerNext_ be ? Await(? IteratorNext(_innerIterator_)).
+                  1. If ? IteratorComplete(_nextNext_) is *true*, set _innerAlive_ to *false*.
+                  1. Else,
+                    1. Let _innerValue_ be ? IteratorValue(_innerNext_).
+                    1. Perform ? Yield(_innerValue_).
         </emu-alg>
       </emu-clause>
 

--- a/spec.html
+++ b/spec.html
@@ -593,7 +593,7 @@ contributors: Gus Caplan
               1. If _usingIterator_ is *undefined*, then
                 1. Perform ? Yield(_mapped_).
               1. Else,
-                1. Let _innerIterator_ be ? GetIterator(_mapped_, ~sync~, _usingIterator_).
+                1. Let _innerIterator_ be ? GetIterator(_mapped_, ~async~, _usingIterator_).
                 1. Let _innerAlive_ be *true*.
                 1. Repeat, while _innerAlive_ is *true*,
                   1. Let _innerNext_ be ? Await(? IteratorNext(_innerIterator_)).

--- a/spec.html
+++ b/spec.html
@@ -597,7 +597,7 @@ contributors: Gus Caplan
                 1. Let _innerAlive_ be *true*.
                 1. Repeat, while _innerAlive_ is *true*,
                   1. Let _innerNext_ be ? Await(? IteratorNext(_innerIterator_)).
-                  1. If ? IteratorComplete(_nextNext_) is *true*, set _innerAlive_ to *false*.
+                  1. If ? IteratorComplete(_innerNext_) is *true*, set _innerAlive_ to *false*.
                   1. Else,
                     1. Let _innerValue_ be ? IteratorValue(_innerNext_).
                     1. Perform ? Yield(_innerValue_).


### PR DESCRIPTION
Currently the spec seems to flatMap only sync iterables from within async iterables, this is presumably a bug as it `Await`s the `IteratorNext()` anyway.

This also fixes that and an unrelated typo referring to a non-existent variable `nextNext`.