### PR TITLE
fix(spec): Make `%Wrap…%.next` pass `value` to `[[Iterated]]`

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -150,11 +150,14 @@ contributors: Gus Caplan
             <h1>The <dfn>%WrapForValidIteratorPrototype%</dfn> Object</h1>
 
             <emu-clause id="sec-wrapforvaliditeratorprototype-next">
-              <h1>%WrapForValidIteratorPrototype%.next ( _v_ )</h1>
+              <h1>%WrapForValidIteratorPrototype%.next ( _value_ )</h1>
               <emu-alg>
                 1. Let _O_ be *this* value.
                 1. RequireInternalSlot(_O_, [[Iterated]]).
-                1. Return ? IteratorNext(_O_.[[Iterated]]).
+                1. If _value_ is not present, then
+                  1. Return ? IteratorNext(_O_.[[Iterated]]).
+                1. Else,
+                  1. Return ? IteratorNext(_O_.[[Iterated]], _value_).
               </emu-alg>
             </emu-clause>
 


### PR DESCRIPTION
This&nbsp;feels&nbsp;like a&nbsp;bug&nbsp;waiting to&nbsp;happen in&nbsp;cases&nbsp;where the&nbsp;wrapped&nbsp;iterator expects&nbsp;`next(…)` to&nbsp;be&nbsp;called with&nbsp;a&nbsp;`value`.