### PR TITLE
Handle errors in flatmap

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -399,14 +399,20 @@ contributors: Gus Caplan
             1. Let _value_ be ? IteratorValue(_next_).
             1. Let _mapped_ be Call(_mapper_, *undefined*, &laquo; _value_ &raquo;).
             1. IfAbruptCloseIterator(_mapped_, _iterated_).
-            1. Let _innerIterator_ be ? GetIterator(_mapped_, ~sync~).
+            1. Let _innerIterator_ be GetIterator(_mapped_, ~sync~).
+            1. IfAbruptCloseIterator(_innerIterator_, _iterated_).
             1. Let _innerAlive_ be *true*.
             1. Repeat, while _innerAlive_ is *true*,
-              1. Let _innerNext_ be ? IteratorNext(_innerIterator_).
-              1. If ? IteratorComplete(_innerNext_) is *false*, set _innerAlive_ to *false*.
+              1. Let _innerNext_ be IteratorNext(_innerIterator_).
+              1. IfAbruptCloseIterator(_innerNext_, _iterated_).
+              1. Let _innerComplete_ be IteratorComplete(_innerNext_).
+              1. IfAbruptCloseIterator(_innerComplete_, _iterated_).
+              1. If _innerComplete_ is *true*, set _innerAlive_ to *false*.
               1. Else,
-                1. Let _innerValue_ be ? IteratorValue(_innerNext_).
-                1. Perform ? Yield(_innerValue_).
+                1. Let _innerValue_ be IteratorValue(_innerNext_).
+                1. IfAbruptCloseIterator(_innerNext_, _iterated_).
+                1. Let _yielded_ be Yield(_innerValue_).
+                1. IfAbruptCloseIterator(_yielded_, _iterated_).
         </emu-alg>
       </emu-clause>
 
@@ -648,14 +654,22 @@ contributors: Gus Caplan
             1. IfAbruptCloseAsyncIterator(_iterated_, _mapped_).
             1. Set _mapped_ to Await(_mapped_).
             1. IfAbruptCloseAsyncIterator(_iterated_, _mapped_).
-            1. Let _innerIterator_ be ? GetIterator(_mapped_, ~async~).
+            1. Let _innerIterator_ be GetIterator(_mapped_, ~async~).
+            1. IfAbruptCloseAsyncIterator(_innerIterator_, _iterated_).
             1. Let _innerAlive_ be *true*.
             1. Repeat, while _innerAlive_ is *true*,
-              1. Let _innerNext_ be ? Await(? IteratorNext(_innerIterator_)).
-              1. If ? IteratorComplete(_innerNext_) is *true*, set _innerAlive_ to *false*.
+              1. Let _innerNextPromise_ be IteratorNext(_innerIterator_).
+              1. IfAbruptCloseAsyncIterator(_innerNextPromise_, _iterated_).
+              1. Let _innerNext_ be Await(_innerNextPromise_).
+              1. IfAbruptCloseAsyncIterator(_innerNext_, _iterated_).
+              1. Let _innerComplete_ be IteratorComplete(_innerNext_).
+              1. IfAbruptCloseAsyncIterator(_innerComplete_, _iterated_).
+              1. If _innerComplete_ is *true*, set _innerAlive_ to *false*.
               1. Else,
-                1. Let _innerValue_ be ? IteratorValue(_innerNext_).
-                1. Perform ? Yield(_innerValue_).
+                1. Let _innerValue_ be IteratorValue(_innerNext_).
+                1. IfAbruptCloseAsyncIterator(_innerNext_, _iterated_).
+                1. Let _yielded_ be Yield(_innerValue_).
+                1. IfAbruptCloseAsyncIterator(_yielded_, _iterated_).
         </emu-alg>
       </emu-clause>
 


### PR DESCRIPTION
When one of the to-be-flattened iterators errors, the receiver iterator should still be closed gracefully.

In the second commit I also switched the first `*false*` to a `*true*` in `If _innerComplete_ is *false*, set _innerAlive_ to *false*.` in `Iterator.prototype.flatMap`, which makes it match `AsyncIterator.prototype.flatMap`. I am pretty sure that makes it match the intent, but haven't checked carefully. Presumably one of the two is wrong prior to this PR, though.