### PR TITLE
fix(IteratorStep): Add the `value` parameter

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -79,6 +79,21 @@ contributors: Gus Caplan
         1. Return _iteratorRecord_.
       </emu-alg>
     </emu-clause>
+
+    <emu-clause id="sec-iteratorstep" aoid="IteratorStep">
+      <h1>IteratorStep ( _iteratorRecord_ <ins>[ , _value_ ]</ins> )</h1>
+
+      <emu-alg>
+        1. <del>Let _result_ be ? IteratorNext(_iteratorRecord_).</del>
+        1. <ins>If _value_ is present, then</ins>
+          1. <ins>Let _result_ be ? IteratorNext(_iteratorRecord_, _value_).</ins>
+        1. <ins>Else,</ins>
+          1. <ins>Let _result_ be ? IteratorNext(_iteratorRecord_).</ins>
+        1. Let _done_ be ? IteratorComplete(_result_).
+        1. If _done_ is *true*, return *false*.
+        1. Return _result_.
+      </emu-alg>
+    </emu-clause>
   </emu-clause>
 </emu-clause>
 


### PR DESCRIPTION
Many&nbsp;`Iterator`&nbsp;methods defined&nbsp;in&nbsp;this&nbsp;specification call&nbsp;`IteratorStep` with&nbsp;`lastValue` as&nbsp;the&nbsp;second&nbsp;parameter, [which&nbsp;isn’t&nbsp;accepted by&nbsp;the&nbsp;current&nbsp;definition in&nbsp;the&nbsp;**ECMAScript**&nbsp;specification](https://tc39.es/ecma262/#sec-iteratorstep).