### PR TITLE
Normative: Add “Well‑Known Intrinsic Objects” table

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -223,7 +223,7 @@ contributors: Gus Caplan
         <h1>Value Properties of the Iterator Constructor</h1>
         <emu-clause id="sec-iterator.prototype">
           <h1>Iterator.prototype</h1>
-          <p>The initial value of Iterator.prototype is %IteratorPrototype%.</p>
+          <p>The initial value of Iterator.prototype is %Iterator.prototype%.</p>
           <p>This property has the attributes { [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
         </emu-clause>
       </emu-clause>
@@ -307,7 +307,7 @@ contributors: Gus Caplan
         <h1>Value Properties of the AsyncIterator Constructor</h1>
         <emu-clause id="sec-asynciterator.prototype">
           <h1>AsyncIterator.prototype</h1>
-          <p>The initial value of AsyncIterator.prototype is %AsyncIteratorPrototype%.</p>
+          <p>The initial value of AsyncIterator.prototype is %AsyncIterator.prototype%.</p>
           <p>This property has the attributes { [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
         </emu-clause>
       </emu-clause>

--- a/spec.html
+++ b/spec.html
@@ -63,6 +63,74 @@ contributors: Gus Caplan
   </ul>
 </div>
 
+<emu-clause id="sec-well-known-intrinsic-objects">
+  <h1>Well-Known Intrinsic Objects</h1>
+
+  <emu-table id="table-7" caption="Well-Known Intrinsic Objects">
+    <table>
+      <tr>
+        <th>
+          Intrinsic Name
+        </th>
+        <th>
+          Global Name
+        </th>
+        <th>
+          ECMAScript Language Association
+        </th>
+      </tr>
+      <tr>
+        <td>
+          <ins>%AsyncIterator%</ins>
+        </td>
+        <td>
+          <ins>`AsyncIterator`</ins>
+        </td>
+        <td>
+          <ins>The `AsyncIterator` constructor (<emu-xref href="#sec-asynciterator-constructor"></emu-xref>)</ins>
+        </td>
+      </tr>
+      <tr>
+        <td>
+          %AsyncIteratorPrototype%
+        </td>
+        <td>
+          <ins>`AsyncIterator.prototype`</ins>
+        </td>
+        <td>
+          An object that all standard built-in async iterator objects indirectly inherit from
+
+          <p><ins>The initial value of the *"prototype"* data property of %AsyncIterator%; i.e., %AsyncIterator.prototype%</ins></p>
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <ins>%Iterator%</ins>
+        </td>
+        <td>
+          <ins>`Iterator`</ins>
+        </td>
+        <td>
+          <ins>The `Iterator` constructor (<emu-xref href="#sec-iterator-constructor"></emu-xref>)</ins>
+        </td>
+      </tr>
+      <tr>
+        <td>
+          %IteratorPrototype%
+        </td>
+        <td>
+          <ins>`Iterator.prototype`</ins>
+        </td>
+        <td>
+          An object that all standard built-in iterator objects indirectly inherit from
+
+          <p><ins>The initial value of the *"prototype"* data property of %Iterator%; i.e., %Iterator.prototype%</ins></p>
+        </td>
+      </tr>
+    </table>
+  </emu-table>
+</emu-clause>
+
 <emu-clause id="sec-abstract-operations">
   <h1>Abstract Operations</h1>
 
@@ -107,6 +175,7 @@ contributors: Gus Caplan
       <h1>The Iterator Constructor</h1>
       <p>The <dfn>Iterator</dfn> constructor:</p>
       <ul>
+        <li>is the intrinsic object <dfn>%Iterator%</dfn>.</li>
         <li>is the initial value of the *Iterator* property of the global object.</li>
         <li>is designed to be subclassable. It may be used as the value of an *extends* clause of a class defintion.</li>
       </ul>
@@ -124,7 +193,7 @@ contributors: Gus Caplan
         <h1>Value Properties of the Iterator Constructor</h1>
         <emu-clause id="sec-iterator.prototype">
           <h1>Iterator.prototype</h1>
-          <p>The initial value of Iterator.prototype is %Iterator.prototype%.</p>
+          <p>The initial value of Iterator.prototype is %IteratorPrototype%.</p>
           <p>This property has the attributes { [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
         </emu-clause>
       </emu-clause>
@@ -190,6 +259,7 @@ contributors: Gus Caplan
       <h1>The AsyncIterator Constructor</h1>
       <p>The <dfn>AsyncIterator</dfn> constructor:</p>
       <ul>
+        <li>is the intrinsic object <dfn>%AsyncIterator%</dfn>.</li>
         <li>is the initial value of the *AsyncIterator* property of the global object.</li>
         <li>is designed to be subclassable. It may be used as the value of an *extends* clause of a class defintion.</li>
       </ul>
@@ -207,7 +277,7 @@ contributors: Gus Caplan
         <h1>Value Properties of the AsyncIterator Constructor</h1>
         <emu-clause id="sec-asynciterator.prototype">
           <h1>AsyncIterator.prototype</h1>
-          <p>The initial value of AsyncIterator.prototype is %AsyncIterator.prototype%.</p>
+          <p>The initial value of AsyncIterator.prototype is %AsyncIteratorPrototype%.</p>
           <p>This property has the attributes { [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
         </emu-clause>
       </emu-clause>
@@ -237,7 +307,7 @@ contributors: Gus Caplan
       </emu-clause>
     </emu-clause>
 
-    <emu-clause id="sec-iteratorprototype-object">
+    <emu-clause id="sec-%iteratorprototype%-object">
       <h1>The <dfn>%Iterator.prototype%</dfn> Object</h1>
 
       <emu-clause id="sec-iteratorprototype-constructor">


### PR DESCRIPTION
This&nbsp;adds the&nbsp;“Well‑Known Intrinsic&nbsp;Objects”&nbsp;table to&nbsp;make it&nbsp;clear that&nbsp;<code>%Iterator.prototype%&nbsp;===&nbsp;%IteratorPrototype%</code> and&nbsp;<code>%AsyncIterator.prototype%&nbsp;===&nbsp;%AsyncIteratorPrototype%</code>.

---

review?(@devsnek, @ljharb)