### PR TITLE
fix: Use correct anchor links

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -103,7 +103,7 @@ contributors: Gus Caplan
   <emu-clause id="sec-iteration">
     <h1>Iteration</h1>
 
-    <emu-clause id="sec-ifabruptcloseiterator">
+    <emu-clause id="sec-ifabruptcloseiterator" aoid="IfAbruptCloseIterator">
       <h1>IfAbruptCloseIterator ( _value_, _iteratorRecord_ )</h1>
       <p><dfn>IfAbruptCloseIterator</dfn> is a shorthand for a sequence of algorithm steps that use an Iterator Record. An algorithm step of the form:</p>
       <emu-alg>
@@ -164,7 +164,7 @@ contributors: Gus Caplan
           <emu-clause id="sec-wrapforvaliditeratorprototype-object">
             <h1>The <dfn>%WrapForValidIteratorPrototype%</dfn> Object</h1>
 
-            <emu-clause id="sec-wrapforvaliditeratorprototype-next">
+            <emu-clause id="sec-wrapforvaliditeratorprototype.next">
               <h1>%WrapForValidIteratorPrototype%.next ( _value_ )</h1>
               <emu-alg>
                 1. Let _O_ be *this* value.
@@ -176,7 +176,7 @@ contributors: Gus Caplan
               </emu-alg>
             </emu-clause>
 
-            <emu-clause id="sec-wrapforvaliditeratorprototype-return">
+            <emu-clause id="sec-wrapforvaliditeratorprototype.return">
               <h1>%WrapForValidIteratorPrototype%.return ( _v_ )</h1>
               <emu-alg>
                 1. Let _O_ be *this* value.
@@ -185,7 +185,7 @@ contributors: Gus Caplan
               </emu-alg>
             </emu-clause>
 
-            <emu-clause id="sec-wrapforvaliditeratorprototype-throw">
+            <emu-clause id="sec-wrapforvaliditeratorprototype.throw">
               <h1>%WrapForValidIteratorPrototype%.throw ( _v_ )</h1>
               <emu-alg>
                 1. Let _O_ be *this* value.
@@ -252,15 +252,15 @@ contributors: Gus Caplan
       </emu-clause>
     </emu-clause>
 
-    <emu-clause id="sec-iteratorprototype-object">
+    <emu-clause id="sec-%iteratorprototype%-object">
       <h1>The <dfn>%Iterator.prototype%</dfn> Object</h1>
 
-      <emu-clause id="sec-iteratorprototype-constructor">
+      <emu-clause id="sec-iteratorprototype.constructor">
         <h1>%Iterator.prototype%.constructor</h1>
         <p>The initial value of %Iterator.prototype%.constructor is %Iterator%.</p>
       </emu-clause>
 
-      <emu-clause id="sec-iteratorprototype-map">
+      <emu-clause id="sec-iteratorprototype.map">
         <h1>%Iterator.prototype%.map ( _mapper_ )</h1>
         <p>%Iterator.prototype%.map is a built-in generator function which, when called, performs the following prelude steps:</p>
         <emu-alg>
@@ -281,7 +281,7 @@ contributors: Gus Caplan
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-iteratorprototype-filter">
+      <emu-clause id="sec-iteratorprototype.filter">
         <h1>%Iterator.prototype%.filter ( _filterer_ )</h1>
         <p>%Iterator.prototype%.filter is a built-in generator function which, when called, performs the following prelude steps:</p>
         <emu-alg>
@@ -303,7 +303,7 @@ contributors: Gus Caplan
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-iteratorprototype-take">
+      <emu-clause id="sec-iteratorprototype.take">
         <h1>%Iterator.prototype%.take ( _limit_ )</h1>
         <p>%Iterator.prototype%.take is a built-in generator function which, when called, performs the following prelude steps:</p>
         <emu-alg>
@@ -324,7 +324,7 @@ contributors: Gus Caplan
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-iteratorprototype-drop">
+      <emu-clause id="sec-iteratorprototype.drop">
         <h1>%Iterator.prototype%.drop ( _limit_ )</h1>
         <p>%Iterator.prototype%.drop is a built-in generator function which, when called, performs the following prelude steps:</p>
         <emu-alg>
@@ -347,7 +347,7 @@ contributors: Gus Caplan
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-iteratorprototype-asindexedpairs">
+      <emu-clause id="sec-iteratorprototype.asindexedpairs">
         <h1>%Iterator.prototype%.asIndexedPairs ( )</h1>
         <p>%Iterator.prototype%.asIndexedPairs is a built-in generator function which, when called, performs the following prelude steps:</p>
         <emu-alg>
@@ -368,7 +368,7 @@ contributors: Gus Caplan
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-iteratorprototype-flatmap">
+      <emu-clause id="sec-iteratorprototype.flatmap">
         <h1>%Iterator.prototype%.flatMap ( _mapper_ )</h1>
         <p>%Iterator.prototype%.flatMap is a built-in generator function which, when called, performs the following steps:</p>
         <emu-alg>
@@ -394,7 +394,7 @@ contributors: Gus Caplan
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-iteratorprototype-reduce">
+      <emu-clause id="sec-iteratorprototype.reduce">
         <h1>%Iterator.prototype%.reduce ( _reducer_ [ , _initialValue_ ] )</h1>
         <emu-alg>
           1. Let _iterated_ be ? GetIteratorDirect(*this* value).
@@ -415,7 +415,7 @@ contributors: Gus Caplan
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-iteratorprototype-toarray">
+      <emu-clause id="sec-iteratorprototype.toarray">
         <h1>%Iterator.prototype%.toArray ( )</h1>
         <emu-alg>
           1. Let _iterated_ be ? GetIteratorDirect(*this* value).
@@ -428,7 +428,7 @@ contributors: Gus Caplan
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-iteratorprototype-foreach">
+      <emu-clause id="sec-iteratorprototype.foreach">
         <h1>%Iterator.prototype%.forEach ( _fn_ )</h1>
         <emu-alg>
           1. Let _iterated_ be ? GetIteratorDirect(*this* value).
@@ -442,7 +442,7 @@ contributors: Gus Caplan
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-iteratorprototype-some">
+      <emu-clause id="sec-iteratorprototype.some">
         <h1>%Iterator.prototype%.some ( _fn_ )</h1>
         <emu-alg>
           1. Let _iterated_ be ? GetIteratorDirect(*this* value).
@@ -457,7 +457,7 @@ contributors: Gus Caplan
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-iteratorprototype-every">
+      <emu-clause id="sec-iteratorprototype.every">
         <h1>%Iterator.prototype%.every ( _fn_ )</h1>
         <emu-alg>
           1. Let _iterated_ be ? GetIteratorDirect(*this* value).
@@ -472,7 +472,7 @@ contributors: Gus Caplan
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-iteratorprototype-find">
+      <emu-clause id="sec-iteratorprototype.find">
         <h1>%Iterator.prototype%.find ( _fn_ )</h1>
         <emu-alg>
           1. Let _iterated_ be ? GetIteratorDirect(*this* value).
@@ -497,12 +497,12 @@ contributors: Gus Caplan
     <emu-clause id="sec-asynciteratorprototype">
       <h1>The <dfn>%AsyncIterator.prototype%</dfn> Object</h1>
 
-      <emu-clause id="sec-asynciteratorprototype-constructor">
+      <emu-clause id="sec-asynciteratorprototype.constructor">
         <h1>%AsyncIterator.prototype%.constructor</h1>
         <p>The initial value of %AsyncIterator.prototype%.constructor is %AsyncIterator%.</p>
       </emu-clause>
 
-      <emu-clause id="sec-asynciteratorprototype-map">
+      <emu-clause id="sec-asynciteratorprototype.map">
         <h1>%AsyncIterator.prototype%.map ( _mapper_ )</h1>
         <p>%AsyncIterator.prototype%.map is a built-in async generator function which, when called, performs the following prelude steps:</p>
         <emu-alg>
@@ -525,7 +525,7 @@ contributors: Gus Caplan
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-asynciteratorprototype-filter">
+      <emu-clause id="sec-asynciteratorprototype.filter">
         <h1>%AsyncIterator.prototype%.filter ( _filterer_ )</h1>
         <p>%AsyncIterator.prototype%.filter is a built-in async generator function which, when called, performs the following prelude steps:</p>
         <emu-alg>
@@ -549,7 +549,7 @@ contributors: Gus Caplan
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-asynciteratorprototype-take">
+      <emu-clause id="sec-asynciteratorprototype.take">
         <h1>%AsyncIterator.prototype%.take ( _limit_ )</h1>
         <p>%AsyncIterator.prototype%.take is a built-in async generator function which, when called, performs the following prelude steps:</p>
         <emu-alg>
@@ -570,7 +570,7 @@ contributors: Gus Caplan
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-asynciteratorprototype-drop">
+      <emu-clause id="sec-asynciteratorprototype.drop">
         <h1>%AsyncIterator.prototype%.drop ( _limit_ )</h1>
         <p>%AsyncIterator.prototype%.drop is a built-in async generator function which, when called, performs the following prelude steps:</p>
         <emu-alg>
@@ -593,7 +593,7 @@ contributors: Gus Caplan
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-asynciteratorprototype-asindexedpairs">
+      <emu-clause id="sec-asynciteratorprototype.asindexedpairs">
         <h1>%AsyncIterator.prototype%.asIndexedPairs ( )</h1>
         <p>%AsyncIterator.prototype%.asIndexedPairs is a built-in async generator function which, when called, performs the following prelude steps:</p>
         <emu-alg>
@@ -614,7 +614,7 @@ contributors: Gus Caplan
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-asynciteratorprototype-flatmap">
+      <emu-clause id="sec-asynciteratorprototype.flatmap">
         <h1>%AsyncIterator.prototype%.flatMap ( _mapper_ )</h1>
         <p>%AsyncIterator.prototype%.flatMap is a built-in async generator function which, when called, performs the following steps:</p>
         <emu-alg>
@@ -642,7 +642,7 @@ contributors: Gus Caplan
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-asynciteratorprototype-reduce">
+      <emu-clause id="sec-asynciteratorprototype.reduce">
         <h1>%AsyncIterator.prototype%.reduce ( _reducer_ [ , _initialValue_ ] )</h1>
         <emu-alg>
           1. Let _iterated_ be ? GetIteratorDirect(*this* value).
@@ -665,7 +665,7 @@ contributors: Gus Caplan
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-asynciteratorprototype-toarray">
+      <emu-clause id="sec-asynciteratorprototype.toarray">
         <h1>%AsyncIterator.prototype%.toArray ( )</h1>
         <p>%AsyncIterator.prototype%.toArray is a built-in async function which, when called, performs the following steps:</p>
         <emu-alg>
@@ -679,7 +679,7 @@ contributors: Gus Caplan
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-asynciteratorprototype-foreach">
+      <emu-clause id="sec-asynciteratorprototype.foreach">
         <h1>%AsyncIterator.prototype%.forEach ( _fn_ )</h1>
         <p>%AsyncIterator.prototype%.forEach is a built-in async function which, when called, performs the following steps:</p>
         <emu-alg>
@@ -696,7 +696,7 @@ contributors: Gus Caplan
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-asynciteratorprototype-some">
+      <emu-clause id="sec-asynciteratorprototype.some">
         <h1>%AsyncIterator.prototype%.some ( _fn_ )</h1>
         <p>%AsyncIterator.prototype%.some is a built-in async function which, when called, performs the following steps:</p>
         <emu-alg>
@@ -714,7 +714,7 @@ contributors: Gus Caplan
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-asynciteratorprototype-every">
+      <emu-clause id="sec-asynciteratorprototype.every">
         <h1>%AsyncIterator.prototype%.every ( _fn_ )</h1>
         <p>%AsyncIterator.prototype%.every is a built-in async function which, when called, performs the following steps:</p>
         <emu-alg>
@@ -732,7 +732,7 @@ contributors: Gus Caplan
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-asynciteratorprototype-find">
+      <emu-clause id="sec-asynciteratorprototype.find">
         <h1>%AsyncIterator.prototype%.find ( _fn_ )</h1>
         <p>%AsyncIterator.prototype%.find is a built-in async function which, when called, performs the following steps:</p>
         <emu-alg>


### PR DESCRIPTION
Modern&nbsp;**ECMAScript**&nbsp;built‑ins use&nbsp;`.` instead&nbsp;of&nbsp;`-` in&nbsp;fragment&nbsp;identifiers.

Also, abstract&nbsp;operations are&nbsp;supposed to&nbsp;have the&nbsp;`aoid`&nbsp;attribute.