### PR TITLE
Add npm library iterare to prior art

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ any form of iterator, different iterators have to be handled differently.
 
 ### Prior Art
 
+- https://www.npmjs.com/package/iterare
 - https://www.npmjs.com/package/itertools
 - https://www.npmjs.com/package/lodash
 - https://docs.python.org/3/library/itertools.html
@@ -81,58 +82,58 @@ any form of iterator, different iterators have to be handled differently.
 - https://docs.microsoft.com/en-us/dotnet/api/system.linq.enumerable
 - https://github.com/ReactiveX/IxJS
 
-| Method                      | Rust | Python | npm Itertools | C# |
-| --------------------------- | ---- | ------ | --------------| -- |
-| all                         | ☑    | ☐      | ☑             | ☑  |
-| any                         | ☑    | ☐      | ☑             | ☑  |
-| chain                       | ☑    | ☑      | ☑             | ☑  |
-| collect                     | ☑    | ☐      | ☐             | ☐  |
-| count                       | ☑    | ☑      | ☑             | ☑  |
-| cycle                       | ☑    | ☑      | ☑             | ☐  |
-| enumerate                   | ☑    | ☐      | ☑             | ☐  |
-| filter                      | ☑    | ☐      | ☑             | ☑  |
-| filterMap                   | ☑    | ☐      | ☐             | ☐  |
-| find                        | ☑    | ☐      | ☑             | ☑  |
-| findMap                     | ☑    | ☐      | ☐             | ☐  |
-| flatMap                     | ☑    | ☐      | ☑             | ☑  |
-| flatten                     | ☑    | ☐      | ☐             | ☐  |
-| forEach                     | ☑    | ☐      | ☐             | ☐  |
-| last                        | ☑    | ☐      | ☐             | ☑  |
-| map                         | ☑    | ☐      | ☑             | ☑  |
-| max                         | ☑    | ☐      | ☑             | ☑  |
-| min                         | ☑    | ☐      | ☑             | ☑  |
-| nth                         | ☑    | ☐      | ☐             | ☑  |
-| partition                   | ☑    | ☑      | ☐             | ☑  |
-| peekable                    | ☑    | ☐      | ☐             | ☐  |
-| position                    | ☑    | ☐      | ☐             | ☐  |
-| product                     | ☑    | ☑      | ☐             | ☐  |
-| reverse                     | ☑    | ☐      | ☐             | ☑  |
-| scan                        | ☑    | ☐      | ☐             | ☐  |
-| skip                        | ☑    | ☐      | ☐             | ☑  |
-| skipWhile                   | ☑    | ☑      | ☐             | ☑  |
-| stepBy                      | ☑    | ☐      | ☐             | ☐  |
-| sum                         | ☑    | ☐      | ☑             | ☑  |
-| take                        | ☑    | ☐      | ☑             | ☑  |
-| takeWhile                   | ☑    | ☑      | ☐             | ☑  |
-| unzip                       | ☑    | ☐      | ☐             | ☐  |
-| zip                         | ☑    | ☑      | ☑             | ☑  |
-| compress                    | ☐    | ☑      | ☑             | ☐  |
-| permutations                | ☐    | ☑      | ☑             | ☐  |
-| repeat                      | ☑    | ☑      | ☑             | ☑  |
-| slice                       | ☐    | ☑      | ☑             | ☐  |
-| starmap                     | ☐    | ☑      | ☐             | ☐  |
-| tee                         | ☐    | ☑      | ☐             | ☐  |
-| compact                     | ☐    | ☐      | ☑             | ☐  |
-| contains                    | ☐    | ☐      | ☑             | ☑  |
-| range                       | ☑    | ☑      | ☑             | ☑  |
-| reduce                      | ☑    | ☑      | ☑             | ☑  |
-| sorted                      | ☐    | ☐      | ☑             | ☐  |
-| unique                      | ☐    | ☐      | ☑             | ☑  |
-| average                     | ☐    | ☐      | ☐             | ☑  |
-| empty                       | ☑    | ☐      | ☐             | ☑  |
-| except                      | ☐    | ☐      | ☐             | ☑  |
-| intersect                   | ☐    | ☐      | ☐             | ☑  |
-| prepend                     | ☐    | ☐      | ☐             | ☑  |
-| append                      | ☐    | ☐      | ☐             | ☑  |
+| Method       | Rust | Python | npm iterare | npm Itertools | C#  |
+| ------------ | ---- | ------ | ----------- | ------------- | --- |
+| all          | ☑    | ☐      | ☑           | ☑             | ☑   |
+| any          | ☑    | ☐      | ☑           | ☑             | ☑   |
+| chain        | ☑    | ☑      | ☑           | ☑             | ☑   |
+| collect      | ☑    | ☐      | ☑           | ☐             | ☐   |
+| count        | ☑    | ☑      | ☐           | ☑             | ☑   |
+| cycle        | ☑    | ☑      | ☐           | ☑             | ☐   |
+| enumerate    | ☑    | ☐      | ☐           | ☑             | ☐   |
+| filter       | ☑    | ☐      | ☑           | ☑             | ☑   |
+| filterMap    | ☑    | ☐      | ☐           | ☐             | ☐   |
+| find         | ☑    | ☐      | ☑           | ☑             | ☑   |
+| findMap      | ☑    | ☐      | ☐           | ☐             | ☐   |
+| flatMap      | ☑    | ☐      | ☐           | ☑             | ☑   |
+| flatten      | ☑    | ☐      | ☑           | ☐             | ☐   |
+| forEach      | ☑    | ☐      | ☑           | ☐             | ☐   |
+| last         | ☑    | ☐      | ☐           | ☐             | ☑   |
+| map          | ☑    | ☐      | ☑           | ☑             | ☑   |
+| max          | ☑    | ☐      | ☐           | ☑             | ☑   |
+| min          | ☑    | ☐      | ☐           | ☑             | ☑   |
+| nth          | ☑    | ☐      | ☐           | ☐             | ☑   |
+| partition    | ☑    | ☑      | ☐           | ☐             | ☑   |
+| peekable     | ☑    | ☐      | ☐           | ☐             | ☐   |
+| position     | ☑    | ☐      | ☐           | ☐             | ☐   |
+| product      | ☑    | ☑      | ☐           | ☐             | ☐   |
+| reverse      | ☑    | ☐      | ☐           | ☐             | ☑   |
+| scan         | ☑    | ☐      | ☐           | ☐             | ☐   |
+| skip         | ☑    | ☐      | ☑           | ☐             | ☑   |
+| skipWhile    | ☑    | ☑      | ☐           | ☐             | ☑   |
+| stepBy       | ☑    | ☐      | ☐           | ☐             | ☐   |
+| sum          | ☑    | ☐      | ☐           | ☑             | ☑   |
+| take         | ☑    | ☐      | ☑           | ☑             | ☑   |
+| takeWhile    | ☑    | ☑      | ☐           | ☐             | ☑   |
+| unzip        | ☑    | ☐      | ☐           | ☐             | ☐   |
+| zip          | ☑    | ☑      | ☐           | ☑             | ☑   |
+| compress     | ☐    | ☑      | ☐           | ☑             | ☐   |
+| permutations | ☐    | ☑      | ☐           | ☑             | ☐   |
+| repeat       | ☑    | ☑      | ☐           | ☑             | ☑   |
+| slice        | ☐    | ☑      | ☑           | ☑             | ☐   |
+| starmap      | ☐    | ☑      | ☐           | ☐             | ☐   |
+| tee          | ☐    | ☑      | ☐           | ☐             | ☐   |
+| compact      | ☐    | ☐      | ☐           | ☑             | ☐   |
+| contains     | ☐    | ☐      | ☑           | ☑             | ☑   |
+| range        | ☑    | ☑      | ☐           | ☑             | ☑   |
+| reduce       | ☑    | ☑      | ☑           | ☑             | ☑   |
+| sorted       | ☐    | ☐      | ☐           | ☑             | ☐   |
+| unique       | ☐    | ☐      | ☐           | ☑             | ☑   |
+| average      | ☐    | ☐      | ☐           | ☐             | ☑   |
+| empty        | ☑    | ☐      | ☐           | ☐             | ☑   |
+| except       | ☐    | ☐      | ☐           | ☐             | ☑   |
+| intersect    | ☐    | ☐      | ☐           | ☐             | ☑   |
+| prepend      | ☐    | ☐      | ☐           | ☐             | ☑   |
+| append       | ☐    | ☐      | ☐           | ☐             | ☑   |
 
 Note: The method names are combined, such as `toArray` and `collect`.


### PR DESCRIPTION
Disclaimer: I wrote `iterare`. My goal here is not to self-promote it though. I would love to see these methods get added to the language itself.

But from reading the README I got the feeling that this proposal primarily considers other languages like Python as inspiration. The mentioned npm library `itertools` seems to be a 1:1  port of the Python stdlib and has 554 weekly downloads. Ix, which comes from Rx, which comes from .NET, has 3,124 weekly downloads. `iterare` on the other hand, which was inspired by ECMAScript's array methods, has 237,799 weekly downloads.

While I use Ix myself in more complex projects, I think this is can be an important data point that the JavaScript community generally prefers a API that mirrors that of array methods, and that the few methods that arrays (and `iterare`) provide are all most JS devs need (as opposed to the whole library of operators that Ix, Python etc have).

But in any case I think a library that is this much more popular than the other libraries listed should be listed too for completeness.