### PR TITLE
Make AsyncIterator.prototype property attributes consistent with Iterator.prototype

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -243,7 +243,7 @@ contributors: Gus Caplan
         <emu-clause id="sec-asynciterator.prototype">
           <h1>AsyncIterator.prototype</h1>
           <p>The initial value of AsyncIterator.prototype is %AsyncIterator.prototype%.</p>
-          <p>This property has the attributes { [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
+          <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
         </emu-clause>
       </emu-clause>
 


### PR DESCRIPTION
After fixing #90, I realized that AsyncIterator.prototype had the same issue and that I should've corrected it then too. Here's the fix for that.