### PR TITLE
Update iterator helpers of Python

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ any form of iterator, different iterators have to be handled differently.
 - https://www.npmjs.com/package/itertools
 - https://www.npmjs.com/package/lodash
 - https://docs.python.org/3/library/itertools.html
+- https://github.com/more-itertools/more-itertools
 - https://docs.rs/itertools/
 - https://doc.rust-lang.org/std/iter/trait.Iterator.html
 - https://www.boost.org/doc/libs/1_66_0/libs/iterator/doc/index.html

--- a/README.md
+++ b/README.md
@@ -83,14 +83,14 @@ any form of iterator, different iterators have to be handled differently.
 
 | Method                      | Rust | Python | npm Itertools | C# |
 | --------------------------- | ---- | ------ | --------------| -- |
-| all                         | ☑    | ☐      | ☑             | ☑  |
-| any                         | ☑    | ☐      | ☑             | ☑  |
+| all                         | ☑    | ☑      | ☑             | ☑  |
+| any                         | ☑    | ☑      | ☑             | ☑  |
 | chain                       | ☑    | ☑      | ☑             | ☑  |
 | collect                     | ☑    | ☐      | ☐             | ☐  |
 | count                       | ☑    | ☑      | ☑             | ☑  |
 | cycle                       | ☑    | ☑      | ☑             | ☐  |
-| enumerate                   | ☑    | ☐      | ☑             | ☐  |
-| filter                      | ☑    | ☐      | ☑             | ☑  |
+| enumerate                   | ☑    | ☑      | ☑             | ☐  |
+| filter                      | ☑    | ☑      | ☑             | ☑  |
 | filterMap                   | ☑    | ☐      | ☐             | ☐  |
 | find                        | ☑    | ☐      | ☑             | ☑  |
 | findMap                     | ☑    | ☐      | ☐             | ☐  |
@@ -98,11 +98,11 @@ any form of iterator, different iterators have to be handled differently.
 | flatten                     | ☑    | ☐      | ☐             | ☐  |
 | forEach                     | ☑    | ☐      | ☐             | ☐  |
 | last                        | ☑    | ☐      | ☐             | ☑  |
-| map                         | ☑    | ☐      | ☑             | ☑  |
-| max                         | ☑    | ☐      | ☑             | ☑  |
-| min                         | ☑    | ☐      | ☑             | ☑  |
+| map                         | ☑    | ☑      | ☑             | ☑  |
+| max                         | ☑    | ☑      | ☑             | ☑  |
+| min                         | ☑    | ☑      | ☑             | ☑  |
 | nth                         | ☑    | ☐      | ☐             | ☑  |
-| partition                   | ☑    | ☑      | ☐             | ☑  |
+| partition                   | ☑    | ☐      | ☐             | ☑  |
 | peekable                    | ☑    | ☐      | ☐             | ☐  |
 | position                    | ☑    | ☐      | ☐             | ☐  |
 | product                     | ☑    | ☑      | ☐             | ☐  |
@@ -111,7 +111,7 @@ any form of iterator, different iterators have to be handled differently.
 | skip                        | ☑    | ☐      | ☐             | ☑  |
 | skipWhile                   | ☑    | ☑      | ☐             | ☑  |
 | stepBy                      | ☑    | ☐      | ☐             | ☐  |
-| sum                         | ☑    | ☐      | ☑             | ☑  |
+| sum                         | ☑    | ☑      | ☑             | ☑  |
 | take                        | ☑    | ☐      | ☑             | ☑  |
 | takeWhile                   | ☑    | ☑      | ☐             | ☑  |
 | unzip                       | ☑    | ☐      | ☐             | ☐  |
@@ -123,10 +123,10 @@ any form of iterator, different iterators have to be handled differently.
 | starmap                     | ☐    | ☑      | ☐             | ☐  |
 | tee                         | ☐    | ☑      | ☐             | ☐  |
 | compact                     | ☐    | ☐      | ☑             | ☐  |
-| contains                    | ☐    | ☐      | ☑             | ☑  |
+| contains                    | ☐    | ☑      | ☑             | ☑  |
 | range                       | ☑    | ☑      | ☑             | ☑  |
 | reduce                      | ☑    | ☑      | ☑             | ☑  |
-| sorted                      | ☐    | ☐      | ☑             | ☐  |
+| sorted                      | ☐    | ☑      | ☑             | ☐  |
 | unique                      | ☐    | ☐      | ☑             | ☑  |
 | average                     | ☐    | ☐      | ☐             | ☑  |
 | empty                       | ☑    | ☐      | ☐             | ☑  |


### PR DESCRIPTION
The prior art matrix is missing some iterator helpers of Python. For example, `all`, `any`, and `enumerate` are built-in iterator helpers which evaluate lazily.