### PR TITLE
Compare to iter-tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ any form of iterator, different iterators have to be handled differently.
 
 ### Prior Art
 
+- https://www.npmjs.com/package/iter-tools
 - https://www.npmjs.com/package/itertools
 - https://www.npmjs.com/package/lodash
 - https://docs.python.org/3/library/itertools.html
@@ -81,58 +82,58 @@ any form of iterator, different iterators have to be handled differently.
 - https://docs.microsoft.com/en-us/dotnet/api/system.linq.enumerable
 - https://github.com/ReactiveX/IxJS
 
-| Method                      | Rust | Python | npm Itertools | C# |
-| --------------------------- | ---- | ------ | --------------| -- |
-| all                         | ☑    | ☐      | ☑             | ☑  |
-| any                         | ☑    | ☐      | ☑             | ☑  |
-| chain                       | ☑    | ☑      | ☑             | ☑  |
-| collect                     | ☑    | ☐      | ☐             | ☐  |
-| count                       | ☑    | ☑      | ☑             | ☑  |
-| cycle                       | ☑    | ☑      | ☑             | ☐  |
-| enumerate                   | ☑    | ☐      | ☑             | ☐  |
-| filter                      | ☑    | ☐      | ☑             | ☑  |
-| filterMap                   | ☑    | ☐      | ☐             | ☐  |
-| find                        | ☑    | ☐      | ☑             | ☑  |
-| findMap                     | ☑    | ☐      | ☐             | ☐  |
-| flatMap                     | ☑    | ☐      | ☑             | ☑  |
-| flatten                     | ☑    | ☐      | ☐             | ☐  |
-| forEach                     | ☑    | ☐      | ☐             | ☐  |
-| last                        | ☑    | ☐      | ☐             | ☑  |
-| map                         | ☑    | ☐      | ☑             | ☑  |
-| max                         | ☑    | ☐      | ☑             | ☑  |
-| min                         | ☑    | ☐      | ☑             | ☑  |
-| nth                         | ☑    | ☐      | ☐             | ☑  |
-| partition                   | ☑    | ☑      | ☐             | ☑  |
-| peekable                    | ☑    | ☐      | ☐             | ☐  |
-| position                    | ☑    | ☐      | ☐             | ☐  |
-| product                     | ☑    | ☑      | ☐             | ☐  |
-| reverse                     | ☑    | ☐      | ☐             | ☑  |
-| scan                        | ☑    | ☐      | ☐             | ☐  |
-| skip                        | ☑    | ☐      | ☐             | ☑  |
-| skipWhile                   | ☑    | ☑      | ☐             | ☑  |
-| stepBy                      | ☑    | ☐      | ☐             | ☐  |
-| sum                         | ☑    | ☐      | ☑             | ☑  |
-| take                        | ☑    | ☐      | ☑             | ☑  |
-| takeWhile                   | ☑    | ☑      | ☐             | ☑  |
-| unzip                       | ☑    | ☐      | ☐             | ☐  |
-| zip                         | ☑    | ☑      | ☑             | ☑  |
-| compress                    | ☐    | ☑      | ☑             | ☐  |
-| permutations                | ☐    | ☑      | ☑             | ☐  |
-| repeat                      | ☑    | ☑      | ☑             | ☑  |
-| slice                       | ☐    | ☑      | ☑             | ☐  |
-| starmap                     | ☐    | ☑      | ☐             | ☐  |
-| tee                         | ☐    | ☑      | ☐             | ☐  |
-| compact                     | ☐    | ☐      | ☑             | ☐  |
-| contains                    | ☐    | ☐      | ☑             | ☑  |
-| range                       | ☑    | ☑      | ☑             | ☑  |
-| reduce                      | ☑    | ☑      | ☑             | ☑  |
-| sorted                      | ☐    | ☐      | ☑             | ☐  |
-| unique                      | ☐    | ☐      | ☑             | ☑  |
-| average                     | ☐    | ☐      | ☐             | ☑  |
-| empty                       | ☑    | ☐      | ☐             | ☑  |
-| except                      | ☐    | ☐      | ☐             | ☑  |
-| intersect                   | ☐    | ☐      | ☐             | ☑  |
-| prepend                     | ☐    | ☐      | ☐             | ☑  |
-| append                      | ☐    | ☐      | ☐             | ☑  |
+| Method                      | Rust | Python | npm Itertools | npm iter-tools | C# |
+| --------------------------- | ---- | ------ | --------------| -------------- | -- |
+| all                         | ☑    | ☐      | ☑             | `every`        | ☑  |
+| any                         | ☑    | ☐      | ☑             | `some`         | ☑  |
+| chain                       | ☑    | ☑      | ☑             | `concat`       | ☑  |
+| collect                     | ☑    | ☐      | ☐             | ☐              | ☐  |
+| count                       | ☑    | ☑      | ☑             | `size`         | ☑  |
+| cycle                       | ☑    | ☑      | ☑             | ☑              | ☐  |
+| enumerate                   | ☑    | ☐      | ☑             | ☑              | ☐  |
+| filter                      | ☑    | ☐      | ☑             | ☑              | ☑  |
+| filterMap                   | ☑    | ☐      | ☐             | ☐              | ☐  |
+| find                        | ☑    | ☐      | ☑             | ☑              | ☑  |
+| findMap                     | ☑    | ☐      | ☐             | ☐              | ☐  |
+| flatMap                     | ☑    | ☐      | ☑             | ☑              | ☑  |
+| flatten                     | ☑    | ☐      | ☐             | `flat`         | ☐  |
+| forEach                     | ☑    | ☐      | ☐             | ☑              | ☐  |
+| last                        | ☑    | ☐      | ☐             | `takeLast`     | ☑  |
+| map                         | ☑    | ☐      | ☑             | ☑              | ☑  |
+| max                         | ☑    | ☐      | ☑             | ☐              | ☑  |
+| min                         | ☑    | ☐      | ☑             | ☐              | ☑  |
+| nth                         | ☑    | ☐      | ☐             | ☐              | ☑  |
+| partition                   | ☑    | ☑      | ☐             | ☐              | ☑  |
+| peekable                    | ☑    | ☐      | ☐             | `peekerate`    | ☐  |
+| position                    | ☑    | ☐      | ☐             | ☐              | ☐  |
+| product                     | ☑    | ☑      | ☐             | ☐              | ☐  |
+| reverse                     | ☑    | ☐      | ☐             | ☑              | ☑  |
+| scan                        | ☑    | ☐      | ☐             | ☐              | ☐  |
+| skip                        | ☑    | ☐      | ☐             | `drop`         | ☑  |
+| skipWhile                   | ☑    | ☑      | ☐             | `dropWhile`    | ☑  |
+| stepBy                      | ☑    | ☐      | ☐             | ☐              | ☐  |
+| sum                         | ☑    | ☐      | ☑             | ☐              | ☑  |
+| take                        | ☑    | ☐      | ☑             | ☑              | ☑  |
+| takeWhile                   | ☑    | ☑      | ☐             | ☑              | ☑  |
+| unzip                       | ☑    | ☐      | ☐             | ☐              | ☐  |
+| zip                         | ☑    | ☑      | ☑             | ☑              | ☑  |
+| compress                    | ☐    | ☑      | ☑             | ☑              | ☐  |
+| permutations                | ☐    | ☑      | ☑             | ☐              | ☐  |
+| repeat                      | ☑    | ☑      | ☑             | ☑              | ☑  |
+| slice                       | ☐    | ☑      | ☑             | ☑              | ☐  |
+| starmap                     | ☐    | ☑      | ☐             | ☐              | ☐  |
+| tee                         | ☐    | ☑      | ☐             | `fork`         | ☐  |
+| compact                     | ☐    | ☐      | ☑             | ☐              | ☐  |
+| contains                    | ☐    | ☐      | ☑             | `includes`     | ☑  |
+| range                       | ☑    | ☑      | ☑             | ☑              | ☑  |
+| reduce                      | ☑    | ☑      | ☑             | ☑              | ☑  |
+| sorted                      | ☐    | ☐      | ☑             | `isSorted`     | ☐  |
+| unique                      | ☐    | ☐      | ☑             | ☐              | ☑  |
+| average                     | ☐    | ☐      | ☐             | ☐              | ☑  |
+| empty                       | ☑    | ☐      | ☐             | ☐              | ☑  |
+| except                      | ☐    | ☐      | ☐             | ☐              | ☑  |
+| intersect                   | ☐    | ☐      | ☐             | ☐              | ☑  |
+| prepend                     | ☐    | ☐      | ☐             | ☑              | ☑  |
+| append                      | ☐    | ☐      | ☐             | ☑              | ☑  |
 
 Note: The method names are combined, such as `toArray` and `collect`.


### PR DESCRIPTION
Adds the `iter-tools` package as a point of comparison. It is under active development, and I am the maintainer.  iter-tools also started life as a python port and uses some of its own terminology, but has also considered other libraries naming for parity purposes, including lodash, the Immutable.js `Seq` class, Ramda, and RxJS, and [async](https://caolan.github.io/async/v3/).