### PR TITLE
update prior art table: reverse, unzip

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ any form of iterator, different iterators have to be handled differently.
 | peekable                    | ☑    | ☐      | ☐             | ☐  |
 | position                    | ☑    | ☐      | ☐             | ☐  |
 | product                     | ☑    | ☑      | ☐             | ☐  |
-| reverse                     | ☑    | ☐      | ☐             | ☑  |
+| reverse                     | ☑    | ☑      | ☐             | ☑  |
 | scan                        | ☑    | ☐      | ☐             | ☐  |
 | skip                        | ☑    | ☐      | ☐             | ☑  |
 | skipWhile                   | ☑    | ☑      | ☐             | ☑  |
@@ -114,7 +114,7 @@ any form of iterator, different iterators have to be handled differently.
 | sum                         | ☑    | ☐      | ☑             | ☑  |
 | take                        | ☑    | ☐      | ☑             | ☑  |
 | takeWhile                   | ☑    | ☑      | ☐             | ☑  |
-| unzip                       | ☑    | ☐      | ☐             | ☐  |
+| unzip                       | ☑    | ☑      | ☑             | ☐  |
 | zip                         | ☑    | ☑      | ☑             | ☑  |
 | compress                    | ☐    | ☑      | ☑             | ☐  |
 | permutations                | ☐    | ☑      | ☑             | ☐  |


### PR DESCRIPTION
Python has built-in `reversed`.

If Rust's greedy (as in not lazy) `unzip` got a check, then Python's `zip(*iterable)`, and npm itertools' `izipMany`, deserve one as well.

~~`average` doesn't belong on this list, for the same reason Python has `statistics.mean`, and not `itertools.average`.~~