### PR TITLE
Editorial: avoid writing to captured aliases

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -483,9 +483,10 @@ contributors: Gus Caplan
         <h1>%Iterator.prototype%.take ( _limit_ )</h1>
         <emu-alg>
           1. Let _iterated_ be ? GetIteratorDirect(*this* value).
-          1. Let _remaining_ be ? ToInteger(_limit_).
-          1. If _remaining_ &lt; 0, throw a *RangeError* exception.
-          1. Let _closure_ be a new Abstract Closure with no parameters that captures _iterated_ and _remaining_ and performs the following steps when called:
+          1. Let _integerLimit_ be ? ToInteger(_limit_).
+          1. If _integerLimit_ &lt; 0, throw a *RangeError* exception.
+          1. Let _closure_ be a new Abstract Closure with no parameters that captures _iterated_ and _integerLimit_ and performs the following steps when called:
+            1. Let _remaining_ be _integerLimit_.
             1. Let _lastValue_ be *undefined*.
             1. Repeat,
               1. If _remaining_ is 0, then
@@ -503,9 +504,10 @@ contributors: Gus Caplan
         <h1>%Iterator.prototype%.drop ( _limit_ )</h1>
         <emu-alg>
           1. Let _iterated_ be ? GetIteratorDirect(*this* value).
-          1. Let _remaining_ be ? ToInteger(_limit_).
-          1. If _remaining_ &lt; 0, throw a *RangeError* exception.
-          1. Let _closure_ be a new Abstract Closure with no parameters that captures _iterated_ and _remaining_ and performs the following steps when called:
+          1. Let _integerLimit_ be ? ToInteger(_limit_).
+          1. If _integerLimit_ &lt; 0, throw a *RangeError* exception.
+          1. Let _closure_ be a new Abstract Closure with no parameters that captures _iterated_ and _integerLimit_ and performs the following steps when called:
+            1. Let _remaining_ be _integerLimit_.
             1. Repeat, while _remaining_ &gt; 0,
               1. Set _remaining_ to _remaining_ - 1.
               1. Let _next_ be ? IteratorStep(_iterated_).
@@ -724,9 +726,10 @@ contributors: Gus Caplan
         <h1>%AsyncIterator.prototype%.take ( _limit_ )</h1>
         <emu-alg>
           1. Let _iterated_ be ? GetIteratorDirect(*this* value).
-          1. Let _remaining_ be ? ToInteger(_limit_).
-          1. If _remaining_ &lt; 0, throw a *RangeError* exception.
-          1. Let _closure_ be a new Abstract Closure with no parameters that captures _iterated_ and _remaining_ and performs the following steps when called:
+          1. Let _integerLimit_ be ? ToInteger(_limit_).
+          1. If _integerLimit_ &lt; 0, throw a *RangeError* exception.
+          1. Let _closure_ be a new Abstract Closure with no parameters that captures _iterated_ and _integerLimit_ and performs the following steps when called:
+            1. Let _remaining_ be _integerLimit_.
             1. Let _lastValue_ be *undefined*.
             1. Repeat,
               1. If _remaining_ is 0, then
@@ -744,9 +747,10 @@ contributors: Gus Caplan
         <h1>%AsyncIterator.prototype%.drop ( _limit_ )</h1>
         <emu-alg>
           1. Let _iterated_ be ? GetIteratorDirect(*this* value).
-          1. Let _remaining_ be ? ToInteger(_limit_).
-          1. If _remaining_ &lt; 0, throw a *RangeError* exception.
-          1. Let _closure_ be a new Abstract Closure with no parameters that captures _iterated_ and _remaining_ and performs the following steps when called:
+          1. Let _integerLimit_ be ? ToInteger(_limit_).
+          1. If _integerLimit_ &lt; 0, throw a *RangeError* exception.
+          1. Let _closure_ be a new Abstract Closure with no parameters that captures _iterated_ and _integerLimit_ and performs the following steps when called:
+            1. Let _remaining_ be _integerLimit_.
             1. Repeat, while _remaining_ &gt; 0,
               1. Set _remaining_ to _remaining_ - 1.
               1. Let _next_ be ? Await(? IteratorNext(_iterated_)).


### PR DESCRIPTION
The [definition of Abstract Closures](https://tc39.es/ecma262/multipage/ecmascript-data-types-and-values.html#sec-abstract-closure) includes

> In algorithm steps that create an Abstract Closure, values are captured with the verb "capture" followed by a list of aliases. When an Abstract Closure is created, it captures the value that is associated with each alias at that time. In steps that specify the algorithm to be performed when an Abstract Closure is called, each captured value is referred to by the alias that was used to capture the value.

So the bits in `.take` and `.drop` that updates `_remaining_` is an editorial error. (Possibly this occurs elsewhere also.) Instead, create a variable within the closure to hold the value.

---

Incidentally, I note these operations are using `ToInteger`. That has been renamed to [`ToIntegerOrInfinity`](https://tc39.es/ecma262/multipage/abstract-operations.html#sec-tointegerorinfinity), which is what that AO has always done. The new name makes it clear that these have another editorial issue, which is that they don't correctly deal with being passed Infinity (they try to subtract 1 from it, which is not well-defined). I assume the intent is that passing Infinity means taking or dropping the whole iterator, so this could be resolved by just guarding the `Set _remaining_ to _remaining_ - 1.` lines by `If _remaining_ is not +∞,`.