### PR TITLE
Fix reduce signature in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ function* naturals() {
 
 const result = naturals()
   .take(5)
-  .reduce((value, sum) => {
+  .reduce((sum, value) => {
     return sum + value;
   }, 3);
 


### PR DESCRIPTION
Confirmed that spec text indeed has the correct signature for `reduce` that matches `Array.prototype.reduce` for both `Iterator` and `AsyncIterator`. This PR fixes the Readme to match.

Resolves #144 