### PR TITLE
Editorial: Restore `<dfn>` for `%Iterator%`

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -193,6 +193,7 @@ contributors: Gus Caplan
         <h1>The Iterator Constructor</h1>
         <p>The <dfn>Iterator</dfn> constructor:</p>
         <ul>
+          <li>is <dfn>%Iterator%</dfn>.</li>
           <li>is the initial value of the *Iterator* property of the global object.</li>
           <li>is designed to be subclassable. It may be used as the value of an *extends* clause of a class definition.</li>
         </ul>
@@ -282,7 +283,7 @@ contributors: Gus Caplan
         <h1>The AsyncIterator Constructor</h1>
         <p>The <dfn>AsyncIterator</dfn> constructor:</p>
         <ul>
-          <li>is the intrinsic object <dfn>%AsyncIterator%</dfn>.</li>
+          <li>is <dfn>%AsyncIterator%</dfn>.</li>
           <li>is the initial value of the *AsyncIterator* property of the global object.</li>
           <li>is designed to be subclassable. It may be used as the value of an *extends* clause of a class definition.</li>
         </ul>


### PR DESCRIPTION
This was accidentally removed in [`0a68525`](https://github.com/tc39/proposal-iterator-helpers/commit/0a6852588fb53cb1ce288994bac35c7245636681#diff-181371b08d71216599b0acccbaabd03c306da6de142ea6275c2135810999805a) by @devsnek.

---

Also updates `<dfn>%AsyncIterator%</dfn>` to use the wording that’s used as of <https://github.com/tc39/ecma262/commit/e68f35a76608ad9587e334e8cd0cbc900cd26061>.