### PR TITLE
fixes #143: rename asIndexedPairs to indexed

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,9 +133,9 @@ result.next(); //  {value: 4, done: false};
 result.next(); //  {value: 5, done: false};
 ```
 
-### `.asIndexedPairs()`
+### `.indexed()`
 
-`.asIndexedPairs` takes no arguments. It returns an iterator where each value produced by the underlying iterator is paired with a counter, starting at 0 and increasing by 1 with every element produced.
+`.indexed` takes no arguments. It returns an iterator where each value produced by the underlying iterator is paired with a counter, starting at 0 and increasing by 1 with every element produced.
 
 Returns an iterator of pairs.
 
@@ -145,7 +145,7 @@ Returns an iterator of pairs.
 const abc = ["a", "b", "c"].values();
 
 const result = abc
-  .asIndexedPairs();
+  .indexed();
 result.next(); //  {value: [0, "a"], done: false};
 result.next(); //  {value: [1, "b"], done: false};
 result.next(); //  {value: [2, "c"], done: false};

--- a/spec.html
+++ b/spec.html
@@ -578,8 +578,8 @@ contributors: Gus Caplan
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-iteratorprototype.asindexedpairs">
-        <h1>%Iterator.prototype%.asIndexedPairs ( )</h1>
+      <emu-clause id="sec-iteratorprototype.indexed">
+        <h1>%Iterator.prototype%.indexed ( )</h1>
         <emu-alg>
           1. Let _iterated_ be ? GetIteratorDirect(*this* value).
           1. Let _closure_ be a new Abstract Closure with no parameters that captures _iterated_ and performs the following steps when called:
@@ -823,8 +823,8 @@ contributors: Gus Caplan
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-asynciteratorprototype.asindexedpairs">
-        <h1>%AsyncIterator.prototype%.asIndexedPairs ( )</h1>
+      <emu-clause id="sec-asynciteratorprototype.indexed">
+        <h1>%AsyncIterator.prototype%.indexed ( )</h1>
         <emu-alg>
           1. Let _iterated_ be ? GetIteratorDirect(*this* value).
           1. Let _closure_ be a new Abstract Closure with no parameters that captures _iterated_ and performs the following steps when called:


### PR DESCRIPTION
Fixes #143.

`zipWithIndex` would also be a reasonable name except that it implies the order would be (value, index) [as it is in Scala](https://www.scala-lang.org/api/2.13.6/scala/collection/View$$ZipWithIndex.html), and I think that's the wrong order.