### PR TITLE
some cleanup of the spec text

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "scripts": {
-    "build": "mkdir -p dist; ecmarkup --strict --load-biblio @tc39/ecma262-biblio --verbose spec.html dist/index.html"
+    "build": "mkdir -p dist && ecmarkup --strict --load-biblio @tc39/ecma262-biblio --verbose --js-out dist/ecmarkup.js --css-out dist/ecmarkup.css spec.html dist/index.html"
   },
   "devDependencies": {
     "@tc39/ecma262-biblio": "2.0.2334",

--- a/spec.html
+++ b/spec.html
@@ -8,8 +8,6 @@ location: https://tc39.es/proposal-iterator-helpers
 copyright: false
 contributors: Gus Caplan
 </pre>
-<script src="ecmarkup.js" defer></script>
-<link rel="stylesheet" href="ecmarkup.css">
 <style>
   ins.block {
     font-weight: bold;

--- a/spec.html
+++ b/spec.html
@@ -230,7 +230,7 @@ contributors: Gus Caplan
           <h1>Iterator.from ( _O_ )</h1>
           <emu-alg>
             1. Let _usingIterator_ be ? GetMethod(_O_, @@iterator).
-            1. If _usingIterator_ is not *undefined*,
+            1. If _usingIterator_ is not *undefined*, then
               1. Let _iteratorRecord_ be ? GetIterator(_O_, ~sync~, _usingIterator_).
               1. Let _hasInstance_ be ? OrdinaryHasInstance(%Iterator%, _iteratorRecord_.[[Iterator]]).
               1. If _hasInstance_ is *true*, then
@@ -252,7 +252,7 @@ contributors: Gus Caplan
               <h1>%WrapForValidIteratorPrototype%.next ( _value_ )</h1>
               <emu-alg>
                 1. Let _O_ be *this* value.
-                1. RequireInternalSlot(_O_, [[Iterated]]).
+                1. Perform ? RequireInternalSlot(_O_, [[Iterated]]).
                 1. If _value_ is not present, then
                   1. Return ? IteratorNext(_O_.[[Iterated]]).
                 1. Else,
@@ -264,7 +264,7 @@ contributors: Gus Caplan
               <h1>%WrapForValidIteratorPrototype%.return ( _v_ )</h1>
               <emu-alg>
                 1. Let _O_ be *this* value.
-                1. RequireInternalSlot(_O_, [[Iterated]]).
+                1. Perform ? RequireInternalSlot(_O_, [[Iterated]]).
                 1. Let _result_ be ? IteratorClose(_O_.[[Iterated]], NormalCompletion(_v_)).
                 1. Return CreateIterResultObject(_result_, true).
               </emu-alg>
@@ -274,7 +274,7 @@ contributors: Gus Caplan
               <h1>%WrapForValidIteratorPrototype%.throw ( _v_ )</h1>
               <emu-alg>
                 1. Let _O_ be *this* value.
-                1. RequireInternalSlot(_O_, [[Iterated]]).
+                1. Perform ? RequireInternalSlot(_O_, [[Iterated]]).
                 1. Let _iterator_ be _O_.[[Iterated]].[[Iterator]].
                 1. Let _throw_ be ? GetMethod(_iterator_, *"throw"*).
                 1. If _throw_ is *undefined*, return ThrowCompletion(_v_).
@@ -320,16 +320,16 @@ contributors: Gus Caplan
           <emu-alg>
             1. Let _usingIterator_ be ? GetMethod(_O_, @@asyncIterator).
             1. Let _iteratorRecord_ be *undefined*.
-            1. If _usingIterator_ is not *undefined*,
+            1. If _usingIterator_ is not *undefined*, then
               1. Set _iteratorRecord_ to ? GetIterator(_O_, ~async~, _usingIterator_).
               1. Let _hasInstance_ be ? OrdinaryHasInstance(%AsyncIterator.prototype%, _iteratorRecord_.[[Iterator]]).
               1. If _hasInstance_ is *true*, then
                 1. Return _iteratorRecord_.[[Iterator]].
-            1. If _iteratorRecord_ is *undefined*,
+            1. If _iteratorRecord_ is *undefined*, then
               1. Set _usingIterator_ to ? GetMethod(_O_, @@iterator).
-              1. If _usingIterator_ is not *undefined*,
+              1. If _usingIterator_ is not *undefined*, then
                 1. Let _syncIteratorRecord_ be ? GetIterator(_O_, ~sync~, _usingIterator_).
-                1. Set _iteratorRecord_ to ! CreateAsyncFromSyncIterator(_syncIteratorRecord_).
+                1. Set _iteratorRecord_ to CreateAsyncFromSyncIterator(_syncIteratorRecord_).
             1. If _iteratorRecord_ is *undefined*, set _iteratorRecord_ to ? GetIteratorDirect(_O_).
             1. Let _wrapper_ be ! ObjectCreate(%WrapForValidAsyncIteratorPrototype%, &laquo; [[AsyncIterated]] &raquo;).
             1. Set _wrapper_.[[AsyncIterated]] to _iteratorRecord_.
@@ -351,12 +351,12 @@ contributors: Gus Caplan
               <emu-alg>
                 1. Let _O_ be *this* value.
                 1. Let _promiseCapability_ be ! NewPromiseCapability(%Promise%).
-                1. Let _check_ be RequireInternalSlot(_O_, [[AsyncIterated]]).
+                1. Let _check_ be Completion(RequireInternalSlot(_O_, [[AsyncIterated]])).
                 1. IfAbruptRejectPromise(_check_, _promiseCapability_).
                 1. If _value_ is not present, then
-                  1. Let _result_ be IteratorNext(_O_.[[AsyncIterated]]).
+                  1. Let _result_ be Completion(IteratorNext(_O_.[[AsyncIterated]])).
                 1. Else,
-                  1. Let _result_ be IteratorNext(_O_.[[AsyncIterated]], _value_).
+                  1. Let _result_ be Completion(IteratorNext(_O_.[[AsyncIterated]], _value_)).
                 1. IfAbruptRejectPromise(_result_, _promiseCapability_).
                 1. Perform ! Call(_promiseCapability_.[[Resolve]], *undefined*, &laquo; _result_ &raquo;).
                 1. Return _promiseCapability_.[[Promise]].
@@ -368,11 +368,11 @@ contributors: Gus Caplan
               <emu-alg>
                 1. Let _O_ be *this* value.
                 1. Let _promiseCapability_ be ! NewPromiseCapability(%Promise%).
-                1. Let _check_ be RequireInternalSlot(_O_, [[AsyncIterated]]).
+                1. Let _check_ be Completion(RequireInternalSlot(_O_, [[AsyncIterated]])).
                 1. IfAbruptRejectPromise(_check_, _promiseCapability_).
-                1. Let _result_ be AsyncIteratorClose(_O_.[[AsyncIterated]], NormalCompletion(_v_)).
+                1. Let _result_ be Completion(AsyncIteratorClose(_O_.[[AsyncIterated]], NormalCompletion(_v_))).
                 1. IfAbruptRejectPromise(_result_, _promiseCapability_).
-                1. Let _iterResult_ be ! CreateIterResultObject(_result_, *true*).
+                1. Let _iterResult_ be CreateIterResultObject(_result_, *true*).
                 1. Perform ! Call(_promiseCapability_.[[Resolve]], *undefined*, &laquo; _iterResult_ &raquo;).
                 1. Return _promiseCapability_.[[Promise]].
               </emu-alg>
@@ -383,15 +383,15 @@ contributors: Gus Caplan
               <emu-alg>
                 1. Let _O_ be *this* value.
                 1. Let _promiseCapability_ be ! NewPromiseCapability(%Promise%).
-                1. Let _check_ be RequireInternalSlot(_O_, [[AsyncIterated]]).
+                1. Let _check_ be Completion(RequireInternalSlot(_O_, [[AsyncIterated]])).
                 1. IfAbruptRejectPromise(_check_, _promiseCapability_).
                 1. Let _iterator_ be _O_.[[AsyncIterated]].[[Iterator]].
-                1. Let _throw_ be GetMethod(_iterator_, *"throw"*).
+                1. Let _throw_ be Completion(GetMethod(_iterator_, *"throw"*)).
                 1. IfAbruptRejectPromise(_throw_, _promiseCapability_).
                 1. If _throw_ is *undefined*, then
                   1. Perform ! Call(_promiseCapability_.[[Reject]], *undefined*, &laquo; _v_ &raquo;).
                   1. Return _promiseCapability_.[[Promise]].
-                1. Let _result_ be Call(_throw_, _iterator_, &laquo; _v_ &raquo;).
+                1. Let _result_ be Completion(Call(_throw_, _iterator_, &laquo; _v_ &raquo;)).
                 1. IfAbruptRejectPromise(_result_, _promiseCapability_).
                 1. Perform ! Call(_promiseCapability_.[[Resolve]], *undefined*, &laquo; _result_ &raquo;).
                 1. Return _promiseCapability_.[[Promise]].
@@ -512,11 +512,11 @@ contributors: Gus Caplan
               1. Let _next_ be ? IteratorStep(_iterated_, _lastValue_).
               1. If _next_ is *false*, return *undefined*.
               1. Let _value_ be ? IteratorValue(_next_).
-              1. Let _mapped_ be Call(_mapper_, *undefined*, &laquo; _value_ &raquo;).
+              1. Let _mapped_ be Completion(Call(_mapper_, *undefined*, &laquo; _value_ &raquo;)).
               1. IfAbruptCloseIterator(_iterated_, _mapped_).
-              1. Set _lastValue_ to Yield(_mapped_).
+              1. Set _lastValue_ to Completion(Yield(_mapped_)).
               1. IfAbruptCloseIterator(_iterated_, _lastValue_).
-          1. Return ? CreateIteratorFromClosure(_closure_, ~Iterator Helper~, %IteratorHelperPrototype%).
+          1. Return CreateIteratorFromClosure(_closure_, ~Iterator Helper~, %IteratorHelperPrototype%).
         </emu-alg>
       </emu-clause>
 
@@ -531,12 +531,12 @@ contributors: Gus Caplan
               1. Let _next_ be ? IteratorStep(_iterated_, _lastValue_).
               1. If _next_ is *false*, return *undefined*.
               1. Let _value_ be ? IteratorValue(_next_).
-              1. Let _selected_ be Call(_filterer_, *undefined*, &laquo; _value_ &raquo;).
+              1. Let _selected_ be Completion(Call(_filterer_, *undefined*, &laquo; _value_ &raquo;)).
               1. IfAbruptCloseIterator(_iterated_, _selected_).
-              1. If ! ToBoolean(_selected_) is *true*,
-                1. Set _lastValue_ to Yield(_value_).
+              1. If ToBoolean(_selected_) is *true*, then
+                1. Set _lastValue_ to Completion(Yield(_value_)).
                 1. IfAbruptCloseIterator(_iterated_, _lastValue_).
-          1. Return ? CreateIteratorFromClosure(_closure_, ~Iterator Helper~, %IteratorHelperPrototype%).
+          1. Return CreateIteratorFromClosure(_closure_, ~Iterator Helper~, %IteratorHelperPrototype%).
         </emu-alg>
       </emu-clause>
 
@@ -558,9 +558,9 @@ contributors: Gus Caplan
                 1. Set _remaining_ to _remaining_ - 1.
               1. Let _next_ be ? IteratorStep(_iterated_, _lastValue_).
               1. If _next_ is *false*, return *undefined*.
-              1. Set _lastValue_ to Yield(? IteratorValue(_next_)).
+              1. Set _lastValue_ to Completion(Yield(? IteratorValue(_next_))).
               1. IfAbruptCloseIterator(_iterated_, _lastValue_).
-          1. Return ? CreateIteratorFromClosure(_closure_, ~Iterator Helper~, %IteratorHelperPrototype%).
+          1. Return CreateIteratorFromClosure(_closure_, ~Iterator Helper~, %IteratorHelperPrototype%).
         </emu-alg>
       </emu-clause>
 
@@ -583,9 +583,9 @@ contributors: Gus Caplan
             1. Repeat,
               1. Let _next_ be ? IteratorStep(_iterated_, _lastValue_).
               1. If _next_ is *false*, return *undefined*.
-              1. Set _lastValue_ to Yield(? IteratorValue(_next_)).
+              1. Set _lastValue_ to Completion(Yield(? IteratorValue(_next_))).
               1. IfAbruptCloseIterator(_iterated_, _lastValue_).
-          1. Return ? CreateIteratorFromClosure(_closure_, ~Iterator Helper~, %IteratorHelperPrototype%).
+          1. Return CreateIteratorFromClosure(_closure_, ~Iterator Helper~, %IteratorHelperPrototype%).
         </emu-alg>
       </emu-clause>
 
@@ -600,11 +600,11 @@ contributors: Gus Caplan
               1. Let _next_ be ? IteratorStep(_iterated_, _lastValue_).
               1. If _next_ is *false*, return *undefined*.
               1. Let _value_ be ? IteratorValue(_next_).
-              1. Let _pair_ be ! CreateArrayFromList(&laquo; _index_, _value_ &raquo;).
+              1. Let _pair_ be CreateArrayFromList(&laquo; _index_, _value_ &raquo;).
               1. Set _index_ to _index_ + 1.
-              1. Set _lastValue_ to Yield(_pair_).
+              1. Set _lastValue_ to Completion(Yield(_pair_)).
               1. IfAbruptCloseIterator(_iterated_, _lastValue_).
-          1. Return ? CreateIteratorFromClosure(_closure_, ~Iterator Helper~, %IteratorHelperPrototype%).
+          1. Return CreateIteratorFromClosure(_closure_, ~Iterator Helper~, %IteratorHelperPrototype%).
         </emu-alg>
       </emu-clause>
 
@@ -618,23 +618,23 @@ contributors: Gus Caplan
               1. Let _next_ be ? IteratorStep(_iterated_).
               1. If _next_ is *false*, return *undefined*.
               1. Let _value_ be ? IteratorValue(_next_).
-              1. Let _mapped_ be Call(_mapper_, *undefined*, &laquo; _value_ &raquo;).
+              1. Let _mapped_ be Completion(Call(_mapper_, *undefined*, &laquo; _value_ &raquo;)).
               1. IfAbruptCloseIterator(_mapped_, _iterated_).
-              1. Let _innerIterator_ be GetIterator(_mapped_, ~sync~).
+              1. Let _innerIterator_ be Completion(GetIterator(_mapped_, ~sync~)).
               1. IfAbruptCloseIterator(_innerIterator_, _iterated_).
               1. Let _innerAlive_ be *true*.
               1. Repeat, while _innerAlive_ is *true*,
-                1. Let _innerNext_ be IteratorNext(_innerIterator_).
+                1. Let _innerNext_ be Completion(IteratorNext(_innerIterator_)).
                 1. IfAbruptCloseIterator(_innerNext_, _iterated_).
-                1. Let _innerComplete_ be IteratorComplete(_innerNext_).
+                1. Let _innerComplete_ be Completion(IteratorComplete(_innerNext_)).
                 1. IfAbruptCloseIterator(_innerComplete_, _iterated_).
                 1. If _innerComplete_ is *true*, set _innerAlive_ to *false*.
                 1. Else,
-                  1. Let _innerValue_ be IteratorValue(_innerNext_).
+                  1. Let _innerValue_ be Completion(IteratorValue(_innerNext_)).
                   1. IfAbruptCloseIterator(_innerValue_, _iterated_).
-                  1. Let _yielded_ be Yield(_innerValue_).
+                  1. Let _yielded_ be Completion(Yield(_innerValue_)).
                   1. IfAbruptCloseIterator(_yielded_, _iterated_).
-          1. Return ? CreateIteratorFromClosure(_closure_, ~Iterator Helper~, %IteratorHelperPrototype%).
+          1. Return CreateIteratorFromClosure(_closure_, ~Iterator Helper~, %IteratorHelperPrototype%).
         </emu-alg>
       </emu-clause>
 
@@ -653,7 +653,7 @@ contributors: Gus Caplan
             1. Let _next_ be ? IteratorStep(_iterated_).
             1. If _next_ is *false*, return _accumulator_.
             1. Let _value_ be ? IteratorValue(_next_).
-            1. Let _result_ be Call(_reducer_, *undefined*, &laquo; _accumulator_, _value_ &raquo;).
+            1. Let _result_ be Completion(Call(_reducer_, *undefined*, &laquo; _accumulator_, _value_ &raquo;)).
             1. IfAbruptCloseIterator(_result_, _iterated_).
             1. Set _accumulator_ to _result_.[[Value]].
         </emu-alg>
@@ -666,7 +666,7 @@ contributors: Gus Caplan
           1. Let _items_ be a new empty List.
           1. Repeat,
             1. Let _next_ be ? IteratorStep(_iterated_).
-            1. If _next_ is *false*, return ! CreateArrayFromList(_items_).
+            1. If _next_ is *false*, return CreateArrayFromList(_items_).
             1. Let _value_ be ? IteratorValue(_next_).
             1. Append _value_ to _items_.
         </emu-alg>
@@ -681,7 +681,7 @@ contributors: Gus Caplan
             1. Let _next_ be ? IteratorStep(_iterated_).
             1. If _next_ is *false*, return *undefined*.
             1. Let _value_ be ? IteratorValue(_next_).
-            1. Let _result_ be Call(_fn_, *undefined*, &laquo; _value_ &raquo;).
+            1. Let _result_ be Completion(Call(_fn_, *undefined*, &laquo; _value_ &raquo;)).
             1. IfAbruptCloseIterator(_result_, _iterated_).
         </emu-alg>
       </emu-clause>
@@ -695,9 +695,9 @@ contributors: Gus Caplan
             1. Let _next_ be ? IteratorStep(_iterated_).
             1. If _next_ is *false*, return *false*.
             1. Let _value_ be ? IteratorValue(_next_).
-            1. Let _result_ be Call(_fn_, *undefined*, &laquo; _value_ &raquo;).
+            1. Let _result_ be Completion(Call(_fn_, *undefined*, &laquo; _value_ &raquo;)).
             1. IfAbruptCloseIterator(_result_, _iterated_).
-            1. If ! ToBoolean(_result_) is *true*, return ? IteratorClose(_iterated_, NormalCompletion(*true*)).
+            1. If ToBoolean(_result_) is *true*, return ? IteratorClose(_iterated_, NormalCompletion(*true*)).
         </emu-alg>
       </emu-clause>
 
@@ -710,9 +710,9 @@ contributors: Gus Caplan
             1. Let _next_ be ? IteratorStep(_iterated_).
             1. If _next_ is *false*, return *true*.
             1. Let _value_ be ? IteratorValue(_next_).
-            1. Let _result_ be Call(_fn_, *undefined*, &laquo; _value_ &raquo;).
+            1. Let _result_ be Completion(Call(_fn_, *undefined*, &laquo; _value_ &raquo;)).
             1. IfAbruptCloseIterator(_result_, _iterated_).
-            1. If ! ToBoolean(_result_) is *false*, return ? IteratorClose(_iterated_, NormalCompletion(*false*)).
+            1. If ToBoolean(_result_) is *false*, return ? IteratorClose(_iterated_, NormalCompletion(*false*)).
         </emu-alg>
       </emu-clause>
 
@@ -725,9 +725,9 @@ contributors: Gus Caplan
             1. Let _next_ be ? IteratorStep(_iterated_).
             1. If _next_ is *false*, return *undefined*.
             1. Let _value_ be ? IteratorValue(_next_).
-            1. Let _result_ be Call(_fn_, *undefined*, &laquo; _value_ &raquo;).
+            1. Let _result_ be Completion(Call(_fn_, *undefined*, &laquo; _value_ &raquo;)).
             1. IfAbruptCloseIterator(_result_, _iterated_).
-            1. If ! ToBoolean(_result_) is *true*, return ? IteratorClose(_iterated_, NormalCompletion(_value_)).
+            1. If ToBoolean(_result_) is *true*, return ? IteratorClose(_iterated_, NormalCompletion(_value_)).
         </emu-alg>
       </emu-clause>
 
@@ -757,13 +757,13 @@ contributors: Gus Caplan
               1. Let _next_ be ? Await(? IteratorNext(_value_, _lastValue_)).
               1. If ? IteratorComplete(_next_) is *true*, return *undefined*.
               1. Let _value_ be ? IteratorValue(_next_).
-              1. Let _mapped_ be Call(_mapper_, *undefined*, &laquo; _value_ &raquo;).
+              1. Let _mapped_ be Completion(Call(_mapper_, *undefined*, &laquo; _value_ &raquo;)).
               1. IfAbruptCloseAsyncIterator(_iterated_, _mapped_).
               1. Set _mapped_ to Await(_mapped_).
               1. IfAbruptCloseAsyncIterator(_iterated_, _mapped_).
-              1. Set _lastValue_ to Yield(_mapped_).
+              1. Set _lastValue_ to Completion(Yield(_mapped_)).
               1. IfAbruptCloseAsyncIterator(_iterated_, _lastValue_).
-          1. Return ? CreateAsyncIteratorFromClosure(_closure_, ~Async Iterator Helper~, %AsyncIteratorHelperPrototype%).
+          1. Return CreateAsyncIteratorFromClosure(_closure_, ~Async Iterator Helper~, %AsyncIteratorHelperPrototype%).
         </emu-alg>
       </emu-clause>
 
@@ -778,14 +778,14 @@ contributors: Gus Caplan
               1. Let _next_ be ? Await(? IteratorNext(_value_, _lastValue_)).
               1. If ? IteratorComplete(_next_) is *true*, return *undefined*.
               1. Let _value_ be ? IteratorValue(_next_).
-              1. Let _selected_ be Call(_filterer_, *undefined*, &laquo; _value_ &raquo;).
+              1. Let _selected_ be Completion(Call(_filterer_, *undefined*, &laquo; _value_ &raquo;)).
               1. IfAbruptCloseAsyncIterator(_iterated_, _selected_).
               1. Set _selected_ to Await(_selected_).
               1. IfAbruptCloseAsyncIterator(_iterated_, _selected_).
-              1. If ! ToBoolean(_selected_) is *true*, then
-                1. Set _lastValue_ to Yield(_value_).
+              1. If ToBoolean(_selected_) is *true*, then
+                1. Set _lastValue_ to Completion(Yield(_value_)).
                 1. IfAbruptCloseAsyncIterator(_iterated_, _lastValue_).
-          1. Return ? CreateAsyncIteratorFromClosure(_closure_, ~Async Iterator Helper~, %AsyncIteratorHelperPrototype%).
+          1. Return CreateAsyncIteratorFromClosure(_closure_, ~Async Iterator Helper~, %AsyncIteratorHelperPrototype%).
         </emu-alg>
       </emu-clause>
 
@@ -807,9 +807,9 @@ contributors: Gus Caplan
                 1. Set _remaining_ to _remaining_ - 1.
               1. Let _next_ be ? Await(? IteratorNext(_iterated_, _lastValue_)).
               1. If ? IteratorComplete(_next_) is *true*, return *undefined*.
-              1. Set _lastValue_ to Yield(? IteratorValue(_next_)).
+              1. Set _lastValue_ to Completion(Yield(? IteratorValue(_next_))).
               1. IfAbruptCloseAsyncIterator(_iterated_, _lastValue_).
-          1. Return ? CreateAsyncIteratorFromClosure(_closure_, ~Async Iterator Helper~, %AsyncIteratorHelperPrototype%).
+          1. Return CreateAsyncIteratorFromClosure(_closure_, ~Async Iterator Helper~, %AsyncIteratorHelperPrototype%).
         </emu-alg>
       </emu-clause>
 
@@ -832,9 +832,9 @@ contributors: Gus Caplan
             1. Repeat,
               1. Let _next_ be ? Await(? IteratorNext(_iterated_, _lastValue_)).
               1. If ? IteratorComplete(_next_) is *true*, return *undefined*.
-              1. Set _lastValue_ to Yield(? IteratorValue(_next_)).
+              1. Set _lastValue_ to Completion(Yield(? IteratorValue(_next_))).
               1. IfAbruptCloseAsyncIterator(_iterated_, _lastValue_).
-          1. Return ? CreateAsyncIteratorFromClosure(_closure_, ~Async Iterator Helper~, %AsyncIteratorHelperPrototype%).
+          1. Return CreateAsyncIteratorFromClosure(_closure_, ~Async Iterator Helper~, %AsyncIteratorHelperPrototype%).
         </emu-alg>
       </emu-clause>
 
@@ -849,11 +849,11 @@ contributors: Gus Caplan
               1. Let _next_ be ? Await(? IteratorNext(_iterated_, _lastValue_)).
               1. If ? IteratorComplete(_next_) is *true*, return *undefined*.
               1. Let _value_ be ? IteratorValue(_next_).
-              1. Let _pair_ be ! CreateArrayFromList(&laquo; _index_, _value_ &raquo;).
+              1. Let _pair_ be CreateArrayFromList(&laquo; _index_, _value_ &raquo;).
               1. Set _index_ to _index_ + 1.
-              1. Set _lastValue_ to Yield(_pair_).
+              1. Set _lastValue_ to Completion(Yield(_pair_)).
               1. IfAbruptCloseAsyncIterator(_iterated_, _lastValue_).
-          1. Return ? CreateAsyncIteratorFromClosure(_closure_, ~Async Iterator Helper~, %AsyncIteratorHelperPrototype%).
+          1. Return CreateAsyncIteratorFromClosure(_closure_, ~Async Iterator Helper~, %AsyncIteratorHelperPrototype%).
         </emu-alg>
       </emu-clause>
 
@@ -868,27 +868,27 @@ contributors: Gus Caplan
               1. Let _next_ be ? Await(? IteratorNext(_iterated_)).
               1. If ? IteratorComplete(_next_) is *true*, return *undefined*.
               1. Let _value_ be ? IteratorValue(_next_).
-              1. Let _mapped_ be Call(_mapper_, *undefined*, &laquo; _value_ &raquo;).
+              1. Let _mapped_ be Completion(Call(_mapper_, *undefined*, &laquo; _value_ &raquo;)).
               1. IfAbruptCloseAsyncIterator(_iterated_, _mapped_).
               1. Set _mapped_ to Await(_mapped_).
               1. IfAbruptCloseAsyncIterator(_iterated_, _mapped_).
-              1. Let _innerIterator_ be GetIterator(_mapped_, ~async~).
+              1. Let _innerIterator_ be Completion(GetIterator(_mapped_, ~async~)).
               1. IfAbruptCloseAsyncIterator(_innerIterator_, _iterated_).
               1. Let _innerAlive_ be *true*.
               1. Repeat, while _innerAlive_ is *true*,
-                1. Let _innerNextPromise_ be IteratorNext(_innerIterator_).
+                1. Let _innerNextPromise_ be Completion(IteratorNext(_innerIterator_)).
                 1. IfAbruptCloseAsyncIterator(_innerNextPromise_, _iterated_).
                 1. Let _innerNext_ be Await(_innerNextPromise_).
                 1. IfAbruptCloseAsyncIterator(_innerNext_, _iterated_).
-                1. Let _innerComplete_ be IteratorComplete(_innerNext_).
+                1. Let _innerComplete_ be Completion(IteratorComplete(_innerNext_)).
                 1. IfAbruptCloseAsyncIterator(_innerComplete_, _iterated_).
                 1. If _innerComplete_ is *true*, set _innerAlive_ to *false*.
                 1. Else,
-                  1. Let _innerValue_ be IteratorValue(_innerNext_).
+                  1. Let _innerValue_ be Completion(IteratorValue(_innerNext_)).
                   1. IfAbruptCloseAsyncIterator(_innerValue_, _iterated_).
-                  1. Let _yielded_ be Yield(_innerValue_).
+                  1. Let _yielded_ be Completion(Yield(_innerValue_)).
                   1. IfAbruptCloseAsyncIterator(_yielded_, _iterated_).
-          1. Return ? CreateAsyncIteratorFromClosure(_closure_, ~Async Iterator Helper~, %AsyncIteratorHelperPrototype%).
+          1. Return CreateAsyncIteratorFromClosure(_closure_, ~Async Iterator Helper~, %AsyncIteratorHelperPrototype%).
         </emu-alg>
       </emu-clause>
 
@@ -907,7 +907,7 @@ contributors: Gus Caplan
             1. Let _next_ be ? Await(? IteratorNext(_iterated_)).
             1. If ? IteratorComplete(_next_) is *true*, return _accumulator_.
             1. Let _value_ be ? IteratorValue(_next_).
-            1. Let _result_ be Call(_reducer_, *undefined*, &laquo; _accumulator_, _value_ &raquo;).
+            1. Let _result_ be Completion(Call(_reducer_, *undefined*, &laquo; _accumulator_, _value_ &raquo;)).
             1. IfAbruptCloseAsyncIterator(_iterated_, _result_).
             1. Set _result_ to Await(_result_).
             1. IfAbruptCloseAsyncIterator(_iterated_, _result_).
@@ -923,7 +923,7 @@ contributors: Gus Caplan
           1. Let _items_ be a new empty List.
           1. Repeat,
             1. Let _next_ be ? Await(? IteratorNext(_iterated_)).
-            1. If ? IteratorComplete(_next_) is *true*, return ! CreateArrayFromList(_items_).
+            1. If ? IteratorComplete(_next_) is *true*, return CreateArrayFromList(_items_).
             1. Let _value_ be ? IteratorValue(_next_).
             1. Append _value_ to _items_.
         </emu-alg>
@@ -939,7 +939,7 @@ contributors: Gus Caplan
             1. Let _next_ be ? Await(? IteratorNext(_iterated_)).
             1. If ? IteratorComplete(_next_) is *true*, return *undefined*.
             1. Let _value_ be ? IteratorValue(_next_).
-            1. Let _r_ be Call(_fn_, *undefined*, &laquo; _value_ &raquo;).
+            1. Let _r_ be Completion(Call(_fn_, *undefined*, &laquo; _value_ &raquo;)).
             1. IfAbruptCloseAsyncIterator(_iterated_, _r_).
             1. Set _r_ to Await(r).
             1. IfAbruptCloseAsyncIterator(_iterated_, _r_).
@@ -956,11 +956,11 @@ contributors: Gus Caplan
             1. Let _next_ be ? Await(? IteratorNext(_iterated_)).
             1. If ? IteratorComplete(_next_) is *true*, return *false*.
             1. Let _value_ be ? IteratorValue(_next_).
-            1. Let _result_ be Call(_fn_, *undefined*, &laquo; _value_ &raquo;).
+            1. Let _result_ be Completion(Call(_fn_, *undefined*, &laquo; _value_ &raquo;)).
             1. IfAbruptCloseAsyncIterator(_iterated_, _result_).
             1. Set _result_ to Await(_result_).
             1. IfAbruptCloseAsyncIterator(_iterated_, _result_).
-            1. If ! ToBoolean(_result_) is *true*, return ? AsyncIteratorClose(_iterated_, NormalCompletion(*true*)).
+            1. If ToBoolean(_result_) is *true*, return ? AsyncIteratorClose(_iterated_, NormalCompletion(*true*)).
         </emu-alg>
       </emu-clause>
 
@@ -974,11 +974,11 @@ contributors: Gus Caplan
             1. Let _next_ be ? Await(? IteratorNext(_iterated_)).
             1. If ? IteratorComplete(_next_) is *true*, return *true*.
             1. Let _value_ be ? IteratorValue(_next_).
-            1. Let _result_ be Call(_fn_, *undefined*, &laquo; _value_ &raquo;).
+            1. Let _result_ be Completion(Call(_fn_, *undefined*, &laquo; _value_ &raquo;)).
             1. IfAbruptCloseAsyncIterator(_iterated_, _result_).
             1. Set _result_ to Await(_result_).
             1. IfAbruptCloseAsyncIterator(_iterated_, _result_).
-            1. If ! ToBoolean(_result_) is *false*, return ? AsyncIteratorClose(_iterated_, NormalCompletion(*false*)).
+            1. If ToBoolean(_result_) is *false*, return ? AsyncIteratorClose(_iterated_, NormalCompletion(*false*)).
         </emu-alg>
       </emu-clause>
 
@@ -992,11 +992,11 @@ contributors: Gus Caplan
             1. Let _next_ be ? Await(? IteratorNext(_iterated_)).
             1. If ? IteratorComplete(_next_) is *true*, return *undefined*.
             1. Let _value_ be ? IteratorValue(_next_).
-            1. Let _result_ be Call(_fn_, *undefined*, &laquo; _value_ &raquo;).
+            1. Let _result_ be Completion(Call(_fn_, *undefined*, &laquo; _value_ &raquo;)).
             1. IfAbruptCloseAsyncIterator(_iterated_, _result_).
             1. Set _result_ to Await(_result_).
             1. IfAbruptCloseAsyncIterator(_iterated_, _result_).
-            1. If ! ToBoolean(_result_) is *true*, return ? AsyncIteratorClose(_iterated_, NormalCompletion(_value_)).
+            1. If ToBoolean(_result_) is *true*, return ? AsyncIteratorClose(_iterated_, NormalCompletion(_value_)).
         </emu-alg>
       </emu-clause>
 
@@ -1016,12 +1016,12 @@ contributors: Gus Caplan
           1. Let _O_ be the *this* value.
           1. <del>Assert: Type(_O_) is Object and _O_ has a [[SyncIteratorRecord]] internal slot.</del>
           1. Let _promiseCapability_ be ! NewPromiseCapability(%Promise%).
-          1. <ins>Let _check_ be RequireInternalSlot(_O_, [[SyncIteratorRecord]]).</ins>
+          1. <ins>Let _check_ be Completion(RequireInternalSlot(_O_, [[SyncIteratorRecord]])).</ins>
           1. <ins>IfAbruptRejectPromise(_check_, _promiseCapability_).</ins>
           1. Let _syncIteratorRecord_ be _O_.[[SyncIteratorRecord]].
-          1. Let _result_ be IteratorNext(_syncIteratorRecord_, _value_).
+          1. Let _result_ be Completion(IteratorNext(_syncIteratorRecord_, _value_)).
           1. IfAbruptRejectPromise(_result_, _promiseCapability_).
-          1. Return ! AsyncFromSyncIteratorContinuation(_result_, _promiseCapability_).
+          1. Return AsyncFromSyncIteratorContinuation(_result_, _promiseCapability_).
         </emu-alg>
       </emu-clause>
 
@@ -1032,20 +1032,20 @@ contributors: Gus Caplan
           1. Let _O_ be the *this* value.
           1. <del>Assert: Type(_O_) is Object and _O_ has a [[SyncIteratorRecord]] internal slot.</del>
           1. Let _promiseCapability_ be ! NewPromiseCapability(%Promise%).
-          1. <ins>Let _check_ be RequireInternalSlot(_O_, [[SyncIteratorRecord]]).</ins>
+          1. <ins>Let _check_ be Completion(RequireInternalSlot(_O_, [[SyncIteratorRecord]])).</ins>
           1. <ins>IfAbruptRejectPromise(_check_, _promiseCapability_).</ins>
-          1. Let _return_ be GetMethod(_syncIterator_, *"return"*).
+          1. Let _return_ be Completion(GetMethod(_syncIterator_, *"return"*)).
           1. IfAbruptRejectPromise(_return_, _promiseCapability_).
           1. If _return_ is *undefined*, then
-            1. Let _iterResult_ be ! CreateIterResultObject(_value_, *true*).
+            1. Let _iterResult_ be CreateIterResultObject(_value_, *true*).
             1. Perform ! Call(_promiseCapability_.[[Resolve]], *undefined*, &laquo; _iterResult_ &raquo;).
             1. Return _promiseCapability_.[[Promise]].
-          1. Let _result_ be Call(_return_, _syncIterator_, &laquo; _value_ &raquo;).
+          1. Let _result_ be Completion(Call(_return_, _syncIterator_, &laquo; _value_ &raquo;)).
           1. IfAbruptRejectPromise(_result_, _promiseCapability_).
           1. If Type(_result_) is not Object, then
             1. Perform ! Call(_promiseCapability_.[[Reject]], *undefined*, &laquo; a newly created *TypeError* object &raquo;).
             1. Return _promiseCapability_.[[Promise]].
-          1. Return ! AsyncFromSyncIteratorContinuation(_result_, _promiseCapability_).
+          1. Return AsyncFromSyncIteratorContinuation(_result_, _promiseCapability_).
         </emu-alg>
       </emu-clause>
 
@@ -1056,20 +1056,20 @@ contributors: Gus Caplan
           1. Let _O_ be the *this* value.
           1. <del>Assert: Type(_O_) is Object and _O_ has a [[SyncIteratorRecord]] internal slot.</del>
           1. Let _promiseCapability_ be ! NewPromiseCapability(%Promise%).
-          1. <ins>Let _check_ be RequireInternalSlot(_O_, [[SyncIteratorRecord]]).</ins>
+          1. <ins>Let _check_ be Completion(RequireInternalSlot(_O_, [[SyncIteratorRecord]])).</ins>
           1. <ins>IfAbruptRejectPromise(_check_, _promiseCapability_).</ins>
           1. Let _syncIterator_ be _O_.[[SyncIteratorRecord]].[[Iterator]].
-          1. Let _throw_ be GetMethod(_syncIterator_, *"throw"*).
+          1. Let _throw_ be Completion(GetMethod(_syncIterator_, *"throw"*)).
           1. IfAbruptRejectPromise(_throw_, _promiseCapability_).
           1. If _throw_ is *undefined*, then
             1. Perform ! Call(_promiseCapability_.[[Reject]], *undefined*, &laquo; _value_ &raquo;).
             1. Return _promiseCapability_.[[Promise]].
-          1. Let _result_ be Call(_throw_, _syncIterator_, &laquo; _value_ &raquo;).
+          1. Let _result_ be Completion(Call(_throw_, _syncIterator_, &laquo; _value_ &raquo;)).
           1. IfAbruptRejectPromise(_result_, _promiseCapability_).
           1. If Type(_result_) is not Object, then
             1. Perform ! Call(_promiseCapability_.[[Reject]], *undefined*, &laquo; a newly created *TypeError* object &raquo;).
             1. Return _promiseCapability_.[[Promise]].
-          1. Return ! AsyncFromSyncIteratorContinuation(_result_, _promiseCapability_).
+          1. Return AsyncFromSyncIteratorContinuation(_result_, _promiseCapability_).
         </emu-alg>
       </emu-clause>
     </emu-clause>

--- a/spec.html
+++ b/spec.html
@@ -493,16 +493,22 @@ contributors: Gus Caplan
       </emu-clause>
     </emu-clause>
 
-    <emu-clause id="sec-%iteratorprototype%-object">
-      <h1>The <dfn>%Iterator.prototype%</dfn> Object</h1>
+    <emu-clause id="sec-iteratorprototype">
+      <h1>Iterator.prototype</h1>
+      <p>The <dfn>Iterator prototype object</dfn>:</p>
+      <ul>
+        <li>is <dfn>%Iterator.prototype%</dfn>.</li>
+        <li>has a [[Prototype]] internal slot whose value is %Object.prototype%.</li>
+        <li>is an ordinary object.</li>
+      </ul>
 
       <emu-clause id="sec-iteratorprototype.constructor">
-        <h1>%Iterator.prototype%.constructor</h1>
+        <h1>Iterator.prototype.constructor</h1>
         <p>The initial value of %Iterator.prototype%.constructor is %Iterator%.</p>
       </emu-clause>
 
       <emu-clause id="sec-iteratorprototype.map">
-        <h1>%Iterator.prototype%.map ( _mapper_ )</h1>
+        <h1>Iterator.prototype.map ( _mapper_ )</h1>
         <emu-alg>
           1. Let _iterated_ be ? GetIteratorDirect(*this* value).
           1. If IsCallable(_mapper_) is *false*, throw a *TypeError* exception.
@@ -521,7 +527,7 @@ contributors: Gus Caplan
       </emu-clause>
 
       <emu-clause id="sec-iteratorprototype.filter">
-        <h1>%Iterator.prototype%.filter ( _filterer_ )</h1>
+        <h1>Iterator.prototype.filter ( _filterer_ )</h1>
         <emu-alg>
           1. Let _iterated_ be ? GetIteratorDirect(*this* value).
           1. If IsCallable(_filterer_) is *false*, throw a *TypeError* exception.
@@ -541,7 +547,7 @@ contributors: Gus Caplan
       </emu-clause>
 
       <emu-clause id="sec-iteratorprototype.take">
-        <h1>%Iterator.prototype%.take ( _limit_ )</h1>
+        <h1>Iterator.prototype.take ( _limit_ )</h1>
         <emu-alg>
           1. Let _iterated_ be ? GetIteratorDirect(*this* value).
           1. Let _numLimit_ be ? ToNumber(_limit_).
@@ -565,7 +571,7 @@ contributors: Gus Caplan
       </emu-clause>
 
       <emu-clause id="sec-iteratorprototype.drop">
-        <h1>%Iterator.prototype%.drop ( _limit_ )</h1>
+        <h1>Iterator.prototype.drop ( _limit_ )</h1>
         <emu-alg>
           1. Let _iterated_ be ? GetIteratorDirect(*this* value).
           1. Let _numLimit_ be ? ToNumber(_limit_).
@@ -590,7 +596,7 @@ contributors: Gus Caplan
       </emu-clause>
 
       <emu-clause id="sec-iteratorprototype.indexed">
-        <h1>%Iterator.prototype%.indexed ( )</h1>
+        <h1>Iterator.prototype.indexed ( )</h1>
         <emu-alg>
           1. Let _iterated_ be ? GetIteratorDirect(*this* value).
           1. Let _closure_ be a new Abstract Closure with no parameters that captures _iterated_ and performs the following steps when called:
@@ -609,7 +615,7 @@ contributors: Gus Caplan
       </emu-clause>
 
       <emu-clause id="sec-iteratorprototype.flatmap">
-        <h1>%Iterator.prototype%.flatMap ( _mapper_ )</h1>
+        <h1>Iterator.prototype.flatMap ( _mapper_ )</h1>
         <emu-alg>
           1. Let _iterated_ be ? GetIteratorDirect(*this* value).
           1. If IsCallable(_mapper_) is *false*, throw a *TypeError* exception.
@@ -639,7 +645,7 @@ contributors: Gus Caplan
       </emu-clause>
 
       <emu-clause id="sec-iteratorprototype.reduce">
-        <h1>%Iterator.prototype%.reduce ( _reducer_ [ , _initialValue_ ] )</h1>
+        <h1>Iterator.prototype.reduce ( _reducer_ [ , _initialValue_ ] )</h1>
         <emu-alg>
           1. Let _iterated_ be ? GetIteratorDirect(*this* value).
           1. If IsCallable(_reducer_) is *false*, throw a *TypeError* exception.
@@ -660,7 +666,7 @@ contributors: Gus Caplan
       </emu-clause>
 
       <emu-clause id="sec-iteratorprototype.toarray">
-        <h1>%Iterator.prototype%.toArray ( )</h1>
+        <h1>Iterator.prototype.toArray ( )</h1>
         <emu-alg>
           1. Let _iterated_ be ? GetIteratorDirect(*this* value).
           1. Let _items_ be a new empty List.
@@ -673,7 +679,7 @@ contributors: Gus Caplan
       </emu-clause>
 
       <emu-clause id="sec-iteratorprototype.foreach">
-        <h1>%Iterator.prototype%.forEach ( _fn_ )</h1>
+        <h1>Iterator.prototype.forEach ( _fn_ )</h1>
         <emu-alg>
           1. Let _iterated_ be ? GetIteratorDirect(*this* value).
           1. If IsCallable(_fn_) is *false*, throw a *TypeError* exception.
@@ -687,7 +693,7 @@ contributors: Gus Caplan
       </emu-clause>
 
       <emu-clause id="sec-iteratorprototype.some">
-        <h1>%Iterator.prototype%.some ( _fn_ )</h1>
+        <h1>Iterator.prototype.some ( _fn_ )</h1>
         <emu-alg>
           1. Let _iterated_ be ? GetIteratorDirect(*this* value).
           1. If IsCallable(_fn_) is *false*, throw a *TypeError* exception.
@@ -702,7 +708,7 @@ contributors: Gus Caplan
       </emu-clause>
 
       <emu-clause id="sec-iteratorprototype.every">
-        <h1>%Iterator.prototype%.every ( _fn_ )</h1>
+        <h1>Iterator.prototype.every ( _fn_ )</h1>
         <emu-alg>
           1. Let _iterated_ be ? GetIteratorDirect(*this* value).
           1. If IsCallable(_fn_) is *false*, throw a *TypeError* exception.
@@ -717,7 +723,7 @@ contributors: Gus Caplan
       </emu-clause>
 
       <emu-clause id="sec-iteratorprototype.find">
-        <h1>%Iterator.prototype%.find ( _fn_ )</h1>
+        <h1>Iterator.prototype.find ( _fn_ )</h1>
         <emu-alg>
           1. Let _iterated_ be ? GetIteratorDirect(*this* value).
           1. If IsCallable(_fn_) is *false*, throw a *TypeError* exception.
@@ -732,22 +738,28 @@ contributors: Gus Caplan
       </emu-clause>
 
       <emu-clause id="sec-iteratorprototype-@@tostringtag">
-        <h1>%Iterator.prototype% [ @@toStringTag ]</h1>
+        <h1>Iterator.prototype [ @@toStringTag ]</h1>
         <p>The initial value of the @@toStringTag property is the String value "Iterator".</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
       </emu-clause>
     </emu-clause>
 
     <emu-clause id="sec-asynciteratorprototype">
-      <h1>The <dfn>%AsyncIterator.prototype%</dfn> Object</h1>
+      <h1>AsyncIterator.prototype</h1>
+      <p>The <dfn>AsyncIterator prototype object</dfn>:</p>
+      <ul>
+        <li>is <dfn>%AsyncIterator.prototype%</dfn>.</li>
+        <li>has a [[Prototype]] internal slot whose value is %Object.prototype%.</li>
+        <li>is an ordinary object.</li>
+      </ul>
 
       <emu-clause id="sec-asynciteratorprototype.constructor">
-        <h1>%AsyncIterator.prototype%.constructor</h1>
-        <p>The initial value of %AsyncIterator.prototype%.constructor is %AsyncIterator%.</p>
+        <h1>AsyncIterator.prototype.constructor</h1>
+        <p>The initial value of AsyncIterator.prototype.constructor is %AsyncIterator%.</p>
       </emu-clause>
 
       <emu-clause id="sec-asynciteratorprototype.map">
-        <h1>%AsyncIterator.prototype%.map ( _mapper_ )</h1>
+        <h1>AsyncIterator.prototype.map ( _mapper_ )</h1>
         <emu-alg>
           1. Let _iterated_ be ? GetIteratorDirect(*this* value).
           1. If IsCallable(_mapper_) is *false*, throw a *TypeError* exception.
@@ -768,7 +780,7 @@ contributors: Gus Caplan
       </emu-clause>
 
       <emu-clause id="sec-asynciteratorprototype.filter">
-        <h1>%AsyncIterator.prototype%.filter ( _filterer_ )</h1>
+        <h1>AsyncIterator.prototype.filter ( _filterer_ )</h1>
         <emu-alg>
           1. Let _iterated_ be ? GetIteratorDirect(*this* value).
           1. If IsCallable(_filterer_) is *false*, throw a *TypeError* exception.
@@ -790,7 +802,7 @@ contributors: Gus Caplan
       </emu-clause>
 
       <emu-clause id="sec-asynciteratorprototype.take">
-        <h1>%AsyncIterator.prototype%.take ( _limit_ )</h1>
+        <h1>AsyncIterator.prototype.take ( _limit_ )</h1>
         <emu-alg>
           1. Let _iterated_ be ? GetIteratorDirect(*this* value).
           1. Let _numLimit_ be ? ToNumber(_limit_).
@@ -814,7 +826,7 @@ contributors: Gus Caplan
       </emu-clause>
 
       <emu-clause id="sec-asynciteratorprototype.drop">
-        <h1>%AsyncIterator.prototype%.drop ( _limit_ )</h1>
+        <h1>AsyncIterator.prototype.drop ( _limit_ )</h1>
         <emu-alg>
           1. Let _iterated_ be ? GetIteratorDirect(*this* value).
           1. Let _numLimit_ be ? ToNumber(_limit_).
@@ -839,7 +851,7 @@ contributors: Gus Caplan
       </emu-clause>
 
       <emu-clause id="sec-asynciteratorprototype.indexed">
-        <h1>%AsyncIterator.prototype%.indexed ( )</h1>
+        <h1>AsyncIterator.prototype.indexed ( )</h1>
         <emu-alg>
           1. Let _iterated_ be ? GetIteratorDirect(*this* value).
           1. Let _closure_ be a new Abstract Closure with no parameters that captures _iterated_ and performs the following steps when called:
@@ -858,8 +870,8 @@ contributors: Gus Caplan
       </emu-clause>
 
       <emu-clause id="sec-asynciteratorprototype.flatmap">
-        <h1>%AsyncIterator.prototype%.flatMap ( _mapper_ )</h1>
-        <p>%AsyncIterator.prototype%.flatMap is a built-in async generator function which, when called, performs the following steps:</p>
+        <h1>AsyncIterator.prototype.flatMap ( _mapper_ )</h1>
+        <p>AsyncIterator.prototype.flatMap is a built-in async generator function which, when called, performs the following steps:</p>
         <emu-alg>
           1. Let _iterated_ be ? GetIteratorDirect(*this* value).
           1. If IsCallable(_mapper_) is *false*, throw a *TypeError* exception.
@@ -893,7 +905,7 @@ contributors: Gus Caplan
       </emu-clause>
 
       <emu-clause id="sec-asynciteratorprototype.reduce">
-        <h1>%AsyncIterator.prototype%.reduce ( _reducer_ [ , _initialValue_ ] )</h1>
+        <h1>AsyncIterator.prototype.reduce ( _reducer_ [ , _initialValue_ ] )</h1>
         <emu-alg>
           1. Let _iterated_ be ? GetIteratorDirect(*this* value).
           1. If IsCallable(_reducer_) is *false*, throw a *TypeError* exception.
@@ -916,8 +928,8 @@ contributors: Gus Caplan
       </emu-clause>
 
       <emu-clause id="sec-asynciteratorprototype.toarray">
-        <h1>%AsyncIterator.prototype%.toArray ( )</h1>
-        <p>%AsyncIterator.prototype%.toArray is a built-in async function which, when called, performs the following steps:</p>
+        <h1>AsyncIterator.prototype.toArray ( )</h1>
+        <p>AsyncIterator.prototype.toArray is a built-in async function which, when called, performs the following steps:</p>
         <emu-alg>
           1. Let _iterated_ be ? GetIteratorDirect(*this* value).
           1. Let _items_ be a new empty List.
@@ -930,8 +942,8 @@ contributors: Gus Caplan
       </emu-clause>
 
       <emu-clause id="sec-asynciteratorprototype.foreach">
-        <h1>%AsyncIterator.prototype%.forEach ( _fn_ )</h1>
-        <p>%AsyncIterator.prototype%.forEach is a built-in async function which, when called, performs the following steps:</p>
+        <h1>AsyncIterator.prototype.forEach ( _fn_ )</h1>
+        <p>AsyncIterator.prototype.forEach is a built-in async function which, when called, performs the following steps:</p>
         <emu-alg>
           1. Let _iterated_ be ? GetIteratorDirect(*this* value).
           1. If IsCallable(_fn_) is *false*, throw a *TypeError* exception.
@@ -947,8 +959,8 @@ contributors: Gus Caplan
       </emu-clause>
 
       <emu-clause id="sec-asynciteratorprototype.some">
-        <h1>%AsyncIterator.prototype%.some ( _fn_ )</h1>
-        <p>%AsyncIterator.prototype%.some is a built-in async function which, when called, performs the following steps:</p>
+        <h1>AsyncIterator.prototype.some ( _fn_ )</h1>
+        <p>AsyncIterator.prototype.some is a built-in async function which, when called, performs the following steps:</p>
         <emu-alg>
           1. Let _iterated_ be ? GetIteratorDirect(*this* value).
           1. If IsCallable(_fn_) is *false*, throw a *TypeError* exception.
@@ -965,8 +977,8 @@ contributors: Gus Caplan
       </emu-clause>
 
       <emu-clause id="sec-asynciteratorprototype.every">
-        <h1>%AsyncIterator.prototype%.every ( _fn_ )</h1>
-        <p>%AsyncIterator.prototype%.every is a built-in async function which, when called, performs the following steps:</p>
+        <h1>AsyncIterator.prototype.every ( _fn_ )</h1>
+        <p>AsyncIterator.prototype.every is a built-in async function which, when called, performs the following steps:</p>
         <emu-alg>
           1. Let _iterated_ be ? GetIteratorDirect(*this* value).
           1. If IsCallable(_fn_) is *false*, throw a *TypeError* exception.
@@ -983,8 +995,8 @@ contributors: Gus Caplan
       </emu-clause>
 
       <emu-clause id="sec-asynciteratorprototype.find">
-        <h1>%AsyncIterator.prototype%.find ( _fn_ )</h1>
-        <p>%AsyncIterator.prototype%.find is a built-in async function which, when called, performs the following steps:</p>
+        <h1>AsyncIterator.prototype.find ( _fn_ )</h1>
+        <p>AsyncIterator.prototype.find is a built-in async function which, when called, performs the following steps:</p>
         <emu-alg>
           1. Let _iterated_ be ? GetIteratorDirect(*this* value).
           1. If IsCallable(_fn_) is *false*, throw a *TypeError* exception.
@@ -1001,7 +1013,7 @@ contributors: Gus Caplan
       </emu-clause>
 
       <emu-clause id="sec-asynciteratorprototype-@@tostringtag">
-        <h1>%AsyncIterator.prototype% [ @@toStringTag ]</h1>
+        <h1>AsyncIterator.prototype [ @@toStringTag ]</h1>
         <p>The initial value of the @@toStringTag property is the String value "Async Iterator".</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
       </emu-clause>

--- a/spec.html
+++ b/spec.html
@@ -131,8 +131,14 @@ contributors: Gus Caplan
   <emu-clause id="sec-operations-on-iterator-objects">
     <h1>Operations on Iterator Objects</h1>
 
-    <emu-clause id="sec-getiteratordirect" aoid="GetIteratorDirect">
-      <h1>GetIteratorDirect ( _obj_ )</h1>
+    <emu-clause id="sec-getiteratordirect" type="abstract operation">
+      <h1>
+        GetIteratorDirect (
+          _obj_: an ECMAScript language value
+        ): either a normal completion containing an IteratorRecord or a throw completion
+      </h1>
+      <dl class="header">
+      </dl>
       <emu-alg>
         1. If Type(_obj_) is not Object, throw a *TypeError* exception.
         1. Let _nextMethod_ be ? GetV(_obj_, `"next"`).
@@ -142,9 +148,15 @@ contributors: Gus Caplan
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-iteratorstep" aoid="IteratorStep">
-      <h1>IteratorStep ( _iteratorRecord_ <ins>[ , _value_ ]</ins> )</h1>
-
+    <emu-clause id="sec-iteratorstep" type="abstract operation">
+      <h1>
+        IteratorStep (
+          _iteratorRecord_: an Iterator Record,
+          <ins>optional value: an ECMAScript language value,</ins>
+        ): either a normal completion containing either an Object or *false*, or a throw completion
+      </h1>
+      <dl class="header">
+      </dl>
       <emu-alg>
         1. <del>Let _result_ be ? IteratorNext(_iteratorRecord_).</del>
         1. <ins>If _value_ is present, then</ins>

--- a/spec.html
+++ b/spec.html
@@ -55,7 +55,7 @@ contributors: Gus Caplan
       <p>Community:</p>
       <ul>
         <li>Discourse: <a href="https://es.discourse.group">https://es.discourse.group</a></li>
-        <li>IRC: <a href="ircs://irc.freenode.net:6667">#tc39</a> on <a href="https://freenode.net/kb/answer/chat">freenode</a></li>
+        <li>Chat: <a href="https://github.com/tc39/how-we-work/blob/HEAD/matrix-guide.md">Matrix</a></li>
       </ul>
     </li>
   </ul>


### PR DESCRIPTION
Unfortunately this doesn't quite get all the way to using `--lint-spec --strict` because that will get caught up on https://github.com/tc39/proposal-iterator-helpers/issues/186, which is outside the scope of this PR.

Commits can be reviewed individually.