### PR TITLE
fixes #190: make wrapped async iterators more efficient

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -324,8 +324,7 @@ contributors: Gus Caplan
                 1. IfAbruptRejectPromise(_check_, _promiseCapability_).
                 1. Let _result_ be Completion(IteratorNext(_O_.[[AsyncIterated]])).
                 1. IfAbruptRejectPromise(_result_, _promiseCapability_).
-                1. Perform ! Call(_promiseCapability_.[[Resolve]], *undefined*, &laquo; _result_ &raquo;).
-                1. Return _promiseCapability_.[[Promise]].
+                1. Return ? PromiseResolve(%Promise%, _result_).
               </emu-alg>
             </emu-clause>
 


### PR DESCRIPTION
Returns the promise directly instead of taking a trip through `[[Resolve]]`. Fixes #190.

/cc @zloirock 