### PR TITLE
rename flatten to flat

### DIFF
--- a/README.md
+++ b/README.md
@@ -450,7 +450,7 @@ any form of iterator, different iterators have to be handled differently.
 | find                        | ☑    | ☐      | ☑             | ☑  |
 | findMap                     | ☑    | ☐      | ☐             | ☐  |
 | flatMap                     | ☑    | ☐      | ☑             | ☑  |
-| flatten                     | ☑    | ☐      | ☐             | ☐  |
+| flat                        | ☑    | ☐      | ☐             | ☐  |
 | forEach                     | ☑    | ☐      | ☐             | ☐  |
 | last                        | ☑    | ☐      | ☐             | ☑  |
 | map                         | ☑    | ☑      | ☑             | ☑  |


### PR DESCRIPTION
[`Array.prototype.flat` exists](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/flat) but not `flatten`