### PR TITLE
fixes #207: add a counter parameter to Array analogues that have indices

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -452,14 +452,16 @@ contributors: Gus Caplan
           1. Let _iterated_ be ? GetIteratorDirect(*this* value).
           1. If IsCallable(_mapper_) is *false*, throw a *TypeError* exception.
           1. Let _closure_ be a new Abstract Closure with no parameters that captures _iterated_ and _mapper_ and performs the following steps when called:
+            1. Let _counter_ be 0.
             1. Repeat,
               1. Let _next_ be ? IteratorStep(_iterated_).
               1. If _next_ is *false*, return *undefined*.
               1. Let _value_ be ? IteratorValue(_next_).
-              1. Let _mapped_ be Completion(Call(_mapper_, *undefined*, « _value_ »)).
+              1. Let _mapped_ be Completion(Call(_mapper_, *undefined*, « _value_, 𝔽(_counter_) »)).
               1. IfAbruptCloseIterator(_mapped_, _iterated_).
               1. Let _completion_ be Completion(Yield(_mapped_)).
               1. IfAbruptCloseIterator(_completion_, _iterated_).
+              1. Set _counter_ to _counter_ + 1.
           1. Return CreateIteratorFromClosure(_closure_, *"Iterator Helper"*, %IteratorHelperPrototype%).
         </emu-alg>
       </emu-clause>
@@ -470,15 +472,17 @@ contributors: Gus Caplan
           1. Let _iterated_ be ? GetIteratorDirect(*this* value).
           1. If IsCallable(_filterer_) is *false*, throw a *TypeError* exception.
           1. Let _closure_ be a new Abstract Closure with no parameters that captures _iterated_ and _filterer_ and performs the following steps when called:
+            1. Let _counter_ be 0.
             1. Repeat,
               1. Let _next_ be ? IteratorStep(_iterated_).
               1. If _next_ is *false*, return *undefined*.
               1. Let _value_ be ? IteratorValue(_next_).
-              1. Let _selected_ be Completion(Call(_filterer_, *undefined*, « _value_ »)).
+              1. Let _selected_ be Completion(Call(_filterer_, *undefined*, « _value_, 𝔽(_counter_) »)).
               1. IfAbruptCloseIterator(_selected_, _iterated_).
               1. If ToBoolean(_selected_) is *true*, then
                 1. Let _completion_ be Completion(Yield(_value_)).
                 1. IfAbruptCloseIterator(_completion_, _iterated_).
+              1. Set _counter_ to _counter_ + 1.
           1. Return CreateIteratorFromClosure(_closure_, *"Iterator Helper"*, %IteratorHelperPrototype%).
         </emu-alg>
       </emu-clause>
@@ -530,35 +534,18 @@ contributors: Gus Caplan
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-iteratorprototype.indexed">
-        <h1>Iterator.prototype.indexed ( )</h1>
-        <emu-alg>
-          1. Let _iterated_ be ? GetIteratorDirect(*this* value).
-          1. Let _closure_ be a new Abstract Closure with no parameters that captures _iterated_ and performs the following steps when called:
-            1. Let _index_ be 0.
-            1. Repeat,
-              1. Let _next_ be ? IteratorStep(_iterated_).
-              1. If _next_ is *false*, return *undefined*.
-              1. Let _value_ be ? IteratorValue(_next_).
-              1. Let _pair_ be CreateArrayFromList(« 𝔽(_index_), _value_ »).
-              1. Set _index_ to _index_ + 1.
-              1. Let _completion_ be Completion(Yield(_pair_)).
-              1. IfAbruptCloseIterator(_completion_, _iterated_).
-          1. Return CreateIteratorFromClosure(_closure_, *"Iterator Helper"*, %IteratorHelperPrototype%).
-        </emu-alg>
-      </emu-clause>
-
       <emu-clause id="sec-iteratorprototype.flatmap">
         <h1>Iterator.prototype.flatMap ( _mapper_ )</h1>
         <emu-alg>
           1. Let _iterated_ be ? GetIteratorDirect(*this* value).
           1. If IsCallable(_mapper_) is *false*, throw a *TypeError* exception.
           1. Let _closure_ be a new Abstract Closure with no parameters that captures _iterated_ and _mapper_ and performs the following steps when called:
+            1. Let _counter_ be 0.
             1. Repeat,
               1. Let _next_ be ? IteratorStep(_iterated_).
               1. If _next_ is *false*, return *undefined*.
               1. Let _value_ be ? IteratorValue(_next_).
-              1. Let _mapped_ be Completion(Call(_mapper_, *undefined*, « _value_ »)).
+              1. Let _mapped_ be Completion(Call(_mapper_, *undefined*, « _value_, 𝔽(_counter_) »)).
               1. IfAbruptCloseIterator(_mapped_, _iterated_).
               1. Let _innerIterator_ be Completion(GetIterator(_mapped_, ~sync~)).
               1. IfAbruptCloseIterator(_innerIterator_, _iterated_).
@@ -576,6 +563,7 @@ contributors: Gus Caplan
                     1. Let _backupCompletion_ be Completion(IteratorClose(_innerIterator_, _completion_)).
                     1. IfAbruptCloseIterator(_backupCompletion_, _iterated_).
                     1. Return ? IteratorClose(_completion_, _iterated_).
+              1. Set _counter_ to _counter_ + 1.
           1. Return CreateIteratorFromClosure(_closure_, *"Iterator Helper"*, %IteratorHelperPrototype%).
         </emu-alg>
       </emu-clause>
@@ -591,13 +579,15 @@ contributors: Gus Caplan
             1. Let _accumulator_ be ? IteratorValue(_next_).
           1. Else,
             1. Let _accumulator_ be _initialValue_.
+          1. Let _counter_ be 0.
           1. Repeat,
             1. Let _next_ be ? IteratorStep(_iterated_).
             1. If _next_ is *false*, return _accumulator_.
             1. Let _value_ be ? IteratorValue(_next_).
-            1. Let _result_ be Completion(Call(_reducer_, *undefined*, « _accumulator_, _value_ »)).
+            1. Let _result_ be Completion(Call(_reducer_, *undefined*, « _accumulator_, _value_, 𝔽(_counter_) »)).
             1. IfAbruptCloseIterator(_result_, _iterated_).
             1. Set _accumulator_ to _result_.[[Value]].
+            1. Set _counter_ to _counter_ + 1.
         </emu-alg>
       </emu-clause>
 
@@ -630,12 +620,14 @@ contributors: Gus Caplan
         <emu-alg>
           1. Let _iterated_ be ? GetIteratorDirect(*this* value).
           1. If IsCallable(_fn_) is *false*, throw a *TypeError* exception.
+          1. Let _counter_ be 0.
           1. Repeat,
             1. Let _next_ be ? IteratorStep(_iterated_).
             1. If _next_ is *false*, return *undefined*.
             1. Let _value_ be ? IteratorValue(_next_).
-            1. Let _result_ be Completion(Call(_fn_, *undefined*, « _value_ »)).
+            1. Let _result_ be Completion(Call(_fn_, *undefined*, « _value_, 𝔽(_counter_) »)).
             1. IfAbruptCloseIterator(_result_, _iterated_).
+            1. Set _counter_ to _counter_ + 1.
         </emu-alg>
       </emu-clause>
 
@@ -644,13 +636,15 @@ contributors: Gus Caplan
         <emu-alg>
           1. Let _iterated_ be ? GetIteratorDirect(*this* value).
           1. If IsCallable(_fn_) is *false*, throw a *TypeError* exception.
+          1. Let _counter_ be 0.
           1. Repeat,
             1. Let _next_ be ? IteratorStep(_iterated_).
             1. If _next_ is *false*, return *false*.
             1. Let _value_ be ? IteratorValue(_next_).
-            1. Let _result_ be Completion(Call(_fn_, *undefined*, « _value_ »)).
+            1. Let _result_ be Completion(Call(_fn_, *undefined*, « _value_, 𝔽(_counter_) »)).
             1. IfAbruptCloseIterator(_result_, _iterated_).
             1. If ToBoolean(_result_) is *true*, return ? IteratorClose(_iterated_, NormalCompletion(*true*)).
+            1. Set _counter_ to _counter_ + 1.
         </emu-alg>
       </emu-clause>
 
@@ -659,13 +653,15 @@ contributors: Gus Caplan
         <emu-alg>
           1. Let _iterated_ be ? GetIteratorDirect(*this* value).
           1. If IsCallable(_fn_) is *false*, throw a *TypeError* exception.
+          1. Let _counter_ be 0.
           1. Repeat,
             1. Let _next_ be ? IteratorStep(_iterated_).
             1. If _next_ is *false*, return *true*.
             1. Let _value_ be ? IteratorValue(_next_).
-            1. Let _result_ be Completion(Call(_fn_, *undefined*, « _value_ »)).
+            1. Let _result_ be Completion(Call(_fn_, *undefined*, « _value_, 𝔽(_counter_) »)).
             1. IfAbruptCloseIterator(_result_, _iterated_).
             1. If ToBoolean(_result_) is *false*, return ? IteratorClose(_iterated_, NormalCompletion(*false*)).
+            1. Set _counter_ to _counter_ + 1.
         </emu-alg>
       </emu-clause>
 
@@ -674,13 +670,15 @@ contributors: Gus Caplan
         <emu-alg>
           1. Let _iterated_ be ? GetIteratorDirect(*this* value).
           1. If IsCallable(_fn_) is *false*, throw a *TypeError* exception.
+          1. Let _counter_ be 0.
           1. Repeat,
             1. Let _next_ be ? IteratorStep(_iterated_).
             1. If _next_ is *false*, return *undefined*.
             1. Let _value_ be ? IteratorValue(_next_).
-            1. Let _result_ be Completion(Call(_fn_, *undefined*, « _value_ »)).
+            1. Let _result_ be Completion(Call(_fn_, *undefined*, « _value_, 𝔽(_counter_) »)).
             1. IfAbruptCloseIterator(_result_, _iterated_).
             1. If ToBoolean(_result_) is *true*, return ? IteratorClose(_iterated_, NormalCompletion(_value_)).
+            1. Set _counter_ to _counter_ + 1.
         </emu-alg>
       </emu-clause>
 
@@ -713,16 +711,18 @@ contributors: Gus Caplan
           1. Let _iterated_ be ? GetIteratorDirect(*this* value).
           1. If IsCallable(_mapper_) is *false*, throw a *TypeError* exception.
           1. Let _closure_ be a new Abstract Closure with no parameters that captures _iterated_ and _mapper_ and performs the following steps when called:
+            1. Let _counter_ be 0.
             1. Repeat,
               1. Let _next_ be ? Await(? IteratorNext(_iterated_)).
               1. If ? IteratorComplete(_next_) is *true*, return *undefined*.
               1. Let _value_ be ? IteratorValue(_next_).
-              1. Let _mapped_ be Completion(Call(_mapper_, *undefined*, « _value_ »)).
+              1. Let _mapped_ be Completion(Call(_mapper_, *undefined*, « _value_, 𝔽(_counter_) »)).
               1. IfAbruptCloseAsyncIterator(_mapped_, _iterated_).
               1. Set _mapped_ to Completion(Await(_mapped_)).
               1. IfAbruptCloseAsyncIterator(_mapped_, _iterated_).
               1. Let _completion_ be Completion(Yield(_mapped_)).
               1. IfAbruptCloseAsyncIterator(_completion_, _iterated_).
+              1. Set _counter_ to _counter_ + 1.
           1. Return CreateAsyncIteratorFromClosure(_closure_, *"Async Iterator Helper"*, %AsyncIteratorHelperPrototype%).
         </emu-alg>
       </emu-clause>
@@ -733,17 +733,19 @@ contributors: Gus Caplan
           1. Let _iterated_ be ? GetIteratorDirect(*this* value).
           1. If IsCallable(_filterer_) is *false*, throw a *TypeError* exception.
           1. Let _closure_ be a new Abstract Closure with no parameters that captures _iterated_ and _filterer_ and performs the following steps when called:
+            1. Let _counter_ be 0.
             1. Repeat,
               1. Let _next_ be ? Await(? IteratorNext(_iterated_)).
               1. If ? IteratorComplete(_next_) is *true*, return *undefined*.
               1. Let _value_ be ? IteratorValue(_next_).
-              1. Let _selected_ be Completion(Call(_filterer_, *undefined*, « _value_ »)).
+              1. Let _selected_ be Completion(Call(_filterer_, *undefined*, « _value_, 𝔽(_counter_) »)).
               1. IfAbruptCloseAsyncIterator(_selected_, _iterated_).
               1. Set _selected_ to Completion(Await(_selected_)).
               1. IfAbruptCloseAsyncIterator(_selected_, _iterated_).
               1. If ToBoolean(_selected_) is *true*, then
                 1. Let _completion_ be Completion(Yield(_value_)).
                 1. IfAbruptCloseAsyncIterator(_completion_, _iterated_).
+              1. Set _counter_ to _counter_ + 1.
           1. Return CreateAsyncIteratorFromClosure(_closure_, *"Async Iterator Helper"*, %AsyncIteratorHelperPrototype%).
         </emu-alg>
       </emu-clause>
@@ -795,24 +797,6 @@ contributors: Gus Caplan
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-asynciteratorprototype.indexed">
-        <h1>AsyncIterator.prototype.indexed ( )</h1>
-        <emu-alg>
-          1. Let _iterated_ be ? GetIteratorDirect(*this* value).
-          1. Let _closure_ be a new Abstract Closure with no parameters that captures _iterated_ and performs the following steps when called:
-            1. Let _index_ be 0.
-            1. Repeat,
-              1. Let _next_ be ? Await(? IteratorNext(_iterated_)).
-              1. If ? IteratorComplete(_next_) is *true*, return *undefined*.
-              1. Let _value_ be ? IteratorValue(_next_).
-              1. Let _pair_ be CreateArrayFromList(« _index_, _value_ »).
-              1. Set _index_ to _index_ + 1.
-              1. Let _completion_ be Completion(Yield(_pair_)).
-              1. IfAbruptCloseAsyncIterator(_completion_, _iterated_).
-          1. Return CreateAsyncIteratorFromClosure(_closure_, *"Async Iterator Helper"*, %AsyncIteratorHelperPrototype%).
-        </emu-alg>
-      </emu-clause>
-
       <emu-clause id="sec-asynciteratorprototype.flatmap">
         <h1>AsyncIterator.prototype.flatMap ( _mapper_ )</h1>
         <p>AsyncIterator.prototype.flatMap is a built-in async generator function which, when called, performs the following steps:</p>
@@ -820,11 +804,12 @@ contributors: Gus Caplan
           1. Let _iterated_ be ? GetIteratorDirect(*this* value).
           1. If IsCallable(_mapper_) is *false*, throw a *TypeError* exception.
           1. Let _closure_ be a new Abstract Closure with no parameters that captures _iterated_ and _mapper_ and performs the following steps when called:
+            1. Let _counter_ be 0.
             1. Repeat,
               1. Let _next_ be ? Await(? IteratorNext(_iterated_)).
               1. If ? IteratorComplete(_next_) is *true*, return *undefined*.
               1. Let _value_ be ? IteratorValue(_next_).
-              1. Let _mapped_ be Completion(Call(_mapper_, *undefined*, « _value_ »)).
+              1. Let _mapped_ be Completion(Call(_mapper_, *undefined*, « _value_, 𝔽(_counter_) »)).
               1. IfAbruptCloseAsyncIterator(_mapped_, _iterated_).
               1. Set _mapped_ to Completion(Await(_mapped_)).
               1. IfAbruptCloseAsyncIterator(_mapped_, _iterated_).
@@ -851,6 +836,7 @@ contributors: Gus Caplan
                   1. Else if _completion_ is a throw completion, then
                     1. Assert: Awaiting _innerValue_ during the Yield on step <emu-xref href="#step-async-iterator-flatmap-yield"></emu-xref> threw.
                     1. Return ? IteratorClose(_completion_, _iterated_).
+              1. Set _counter_ to _counter_ + 1.
           1. Return CreateAsyncIteratorFromClosure(_closure_, *"Async Iterator Helper"*, %AsyncIteratorHelperPrototype%).
         </emu-alg>
       </emu-clause>
@@ -866,15 +852,17 @@ contributors: Gus Caplan
             1. Let _accumulator_ be ? IteratorValue(_next_).
           1. Else,
             1. Let _accumulator_ be _initialValue_.
+          1. Let _counter_ be 0.
           1. Repeat,
             1. Let _next_ be ? Await(? IteratorNext(_iterated_)).
             1. If ? IteratorComplete(_next_) is *true*, return _accumulator_.
             1. Let _value_ be ? IteratorValue(_next_).
-            1. Let _result_ be Completion(Call(_reducer_, *undefined*, « _accumulator_, _value_ »)).
+            1. Let _result_ be Completion(Call(_reducer_, *undefined*, « _accumulator_, _value_, 𝔽(_counter_) »)).
             1. IfAbruptCloseAsyncIterator(_result_, _iterated_).
             1. Set _result_ to Await(_result_).
             1. IfAbruptCloseAsyncIterator(_result_, _iterated_).
             1. Set _accumulator_ to _result_.
+            1. Set _counter_ to _counter_ + 1.
         </emu-alg>
       </emu-clause>
 
@@ -898,14 +886,16 @@ contributors: Gus Caplan
         <emu-alg>
           1. Let _iterated_ be ? GetIteratorDirect(*this* value).
           1. If IsCallable(_fn_) is *false*, throw a *TypeError* exception.
+          1. Let _counter_ be 0.
           1. Repeat,
             1. Let _next_ be ? Await(? IteratorNext(_iterated_)).
             1. If ? IteratorComplete(_next_) is *true*, return *undefined*.
             1. Let _value_ be ? IteratorValue(_next_).
-            1. Let _r_ be Completion(Call(_fn_, *undefined*, « _value_ »)).
+            1. Let _r_ be Completion(Call(_fn_, *undefined*, « _value_, 𝔽(_counter_) »)).
             1. IfAbruptCloseAsyncIterator(_r_, _iterated_).
             1. Set _r_ to Await(r).
             1. IfAbruptCloseAsyncIterator(_r_, _iterated_).
+            1. Set _counter_ to _counter_ + 1.
         </emu-alg>
       </emu-clause>
 
@@ -915,15 +905,17 @@ contributors: Gus Caplan
         <emu-alg>
           1. Let _iterated_ be ? GetIteratorDirect(*this* value).
           1. If IsCallable(_fn_) is *false*, throw a *TypeError* exception.
+          1. Let _counter_ be 0.
           1. Repeat,
             1. Let _next_ be ? Await(? IteratorNext(_iterated_)).
             1. If ? IteratorComplete(_next_) is *true*, return *false*.
             1. Let _value_ be ? IteratorValue(_next_).
-            1. Let _result_ be Completion(Call(_fn_, *undefined*, « _value_ »)).
+            1. Let _result_ be Completion(Call(_fn_, *undefined*, « _value_, 𝔽(_counter_) »)).
             1. IfAbruptCloseAsyncIterator(_result_, _iterated_).
             1. Set _result_ to Await(_result_).
             1. IfAbruptCloseAsyncIterator(_result_, _iterated_).
             1. If ToBoolean(_result_) is *true*, return ? AsyncIteratorClose(_iterated_, NormalCompletion(*true*)).
+            1. Set _counter_ to _counter_ + 1.
         </emu-alg>
       </emu-clause>
 
@@ -933,15 +925,17 @@ contributors: Gus Caplan
         <emu-alg>
           1. Let _iterated_ be ? GetIteratorDirect(*this* value).
           1. If IsCallable(_fn_) is *false*, throw a *TypeError* exception.
+          1. Let _counter_ be 0.
           1. Repeat,
             1. Let _next_ be ? Await(? IteratorNext(_iterated_)).
             1. If ? IteratorComplete(_next_) is *true*, return *true*.
             1. Let _value_ be ? IteratorValue(_next_).
-            1. Let _result_ be Completion(Call(_fn_, *undefined*, « _value_ »)).
+            1. Let _result_ be Completion(Call(_fn_, *undefined*, « _value_, 𝔽(_counter_) »)).
             1. IfAbruptCloseAsyncIterator(_result_, _iterated_).
             1. Set _result_ to Await(_result_).
             1. IfAbruptCloseAsyncIterator(_result_, _iterated_).
             1. If ToBoolean(_result_) is *false*, return ? AsyncIteratorClose(_iterated_, NormalCompletion(*false*)).
+            1. Set _counter_ to _counter_ + 1.
         </emu-alg>
       </emu-clause>
 
@@ -951,15 +945,17 @@ contributors: Gus Caplan
         <emu-alg>
           1. Let _iterated_ be ? GetIteratorDirect(*this* value).
           1. If IsCallable(_fn_) is *false*, throw a *TypeError* exception.
+          1. Let _counter_ be 0.
           1. Repeat,
             1. Let _next_ be ? Await(? IteratorNext(_iterated_)).
             1. If ? IteratorComplete(_next_) is *true*, return *undefined*.
             1. Let _value_ be ? IteratorValue(_next_).
-            1. Let _result_ be Completion(Call(_fn_, *undefined*, « _value_ »)).
+            1. Let _result_ be Completion(Call(_fn_, *undefined*, « _value_, 𝔽(_counter_) »)).
             1. IfAbruptCloseAsyncIterator(_result_, _iterated_).
             1. Set _result_ to Await(_result_).
             1. IfAbruptCloseAsyncIterator(_result_, _iterated_).
             1. If ToBoolean(_result_) is *true*, return ? AsyncIteratorClose(_iterated_, NormalCompletion(_value_)).
+            1. Set _counter_ to _counter_ + 1.
         </emu-alg>
       </emu-clause>
 


### PR DESCRIPTION
Fixes #207. Adds "counter" parameters to callbacks of methods that have an `Array.prototype` analogue that passes an index to its callback. Also removes `.indexed()` now that it's equivalent to `.map((a, i) => [i, a])`.

Feedback on #207 has been mixed. I am not yet convinced that this is an improvement, but I am also not opposed to this change if that's what the committee decides.