### PR TITLE
use ! with a PromiseResolve call that can't fail

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -345,7 +345,8 @@ contributors: Gus Caplan
                 1. Let _returnMethod_ be Completion(GetMethod(_iterator_, *"return"*)).
                 1. IfAbruptRejectPromise(_returnMethod_, _promiseCapability_).
                 1. If _returnMethod_ is *undefined*, then
-                  1. Return ? PromiseResolve(%Promise%, CreateIterResultObject(*undefined*, *true*)).
+                  1. Perform ! Call(_promiseCapability_.[[Resolve]], *undefined*, &laquo; CreateIterResultObject(*undefined*, *true*) &raquo;).
+                  1. Return _promiseCapability_.[[Promise]].
                 1. Let _result_ be Completion(Call(_returnMethod_, _iterator_)).
                 1. IfAbruptRejectPromise(_result_, _promiseCapability_).
                 1. Return ? PromiseResolve(%Promise%, _result_).

--- a/spec.html
+++ b/spec.html
@@ -345,8 +345,7 @@ contributors: Gus Caplan
                 1. Let _returnMethod_ be Completion(GetMethod(_iterator_, *"return"*)).
                 1. IfAbruptRejectPromise(_returnMethod_, _promiseCapability_).
                 1. If _returnMethod_ is *undefined*, then
-                  1. Perform ! Call(_promiseCapability_.[[Resolve]], *undefined*, &laquo; CreateIterResultObject(*undefined*, *true*) &raquo;).
-                  1. Return _promiseCapability_.[[Promise]].
+                  1. Return ! PromiseResolve(%Promise%, CreateIterResultObject(*undefined*, *true*)).
                 1. Let _result_ be Completion(Call(_returnMethod_, _iterator_)).
                 1. IfAbruptRejectPromise(_result_, _promiseCapability_).
                 1. Return ? PromiseResolve(%Promise%, _result_).


### PR DESCRIPTION
A slight tweak to https://github.com/tc39/proposal-iterator-helpers/pull/215.

The reason to use PromiseResolve is to get the fast-path when the value being passed is expected to be a Promise. On this particular line we've just created the iterator result object with which we are resolving, so we know the value is not a Promise. This is equivalent but (I think) clearer.

If this isn't accepted, the `?` in the `Return ? PromiseResolve` should at least be changed to `!`, since the throwy case is guarded on `IsPromise` of the argument.