### PR TITLE
fixes #219: take closes iterator earlier

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -501,6 +501,7 @@ contributors: Gus Caplan
               1. If _remaining_ is 0, then
                 1. Perform ? IteratorClose(_iterated_, NormalCompletion(*undefined*)).
                 1. Perform ? Yield(_value_).
+                1. Return *undefined*.
               1. Let _completion_ be Completion(Yield(_value_)).
               1. IfAbruptCloseIterator(_completion_, _iterated_).
           1. Return CreateIteratorFromClosure(_closure_, ~Iterator Helper~, %IteratorHelperPrototype%).
@@ -756,15 +757,20 @@ contributors: Gus Caplan
           1. Let _integerLimit_ be ! ToIntegerOrInfinity(_numLimit_).
           1. If _integerLimit_ &lt; 0, throw a *RangeError* exception.
           1. Let _closure_ be a new Abstract Closure with no parameters that captures _iterated_ and _integerLimit_ and performs the following steps when called:
+            1. If _integerLimit_ is 0, then
+              1. Return ? AsyncIteratorClose(_iterated_, NormalCompletion(*undefined*)).
             1. Let _remaining_ be _integerLimit_.
             1. Repeat,
-              1. If _remaining_ is 0, then
-                1. Return ? AsyncIteratorClose(_iterated_, NormalCompletion(*undefined*)).
-              1. If _remaining_ is not +∞, then
-                1. Set _remaining_ to _remaining_ - 1.
               1. Let _next_ be ? Await(? IteratorNext(_iterated_)).
               1. If ? IteratorComplete(_next_) is *true*, return *undefined*.
-              1. Set _completion_ to Completion(Yield(? IteratorValue(_next_))).
+              1. If _remaining_ is not +∞, then
+                1. Set _remaining_ to _remaining_ - 1.
+              1. Let _value_ be ? IteratorValue(_next_).
+              1. If _remaining_ is 0, then
+                1. Perform ? AsyncIteratorClose(_iterated_, NormalCompletion(*undefined*)).
+                1. Perform ? Yield(_value_).
+                1. Return *undefined*.
+              1. Set _completion_ to Completion(Yield(_value_)).
               1. IfAbruptCloseAsyncIterator(_completion_, _iterated_).
           1. Return CreateAsyncIteratorFromClosure(_closure_, ~Async Iterator Helper~, %AsyncIteratorHelperPrototype%).
         </emu-alg>

--- a/spec.html
+++ b/spec.html
@@ -489,15 +489,19 @@ contributors: Gus Caplan
           1. Let _integerLimit_ be ! ToIntegerOrInfinity(_numLimit_).
           1. If _integerLimit_ &lt; 0, throw a *RangeError* exception.
           1. Let _closure_ be a new Abstract Closure with no parameters that captures _iterated_ and _integerLimit_ and performs the following steps when called:
+            1. If _integerLimit_ is 0, then
+              1. Return ? IteratorClose(_iterated_, NormalCompletion(*undefined*)).
             1. Let _remaining_ be _integerLimit_.
             1. Repeat,
-              1. If _remaining_ is 0, then
-                1. Return ? IteratorClose(_iterated_, NormalCompletion(*undefined*)).
-              1. If _remaining_ is not +∞, then
-                1. Set _remaining_ to _remaining_ - 1.
               1. Let _next_ be ? IteratorStep(_iterated_).
               1. If _next_ is *false*, return *undefined*.
-              1. Let _completion_ be Completion(Yield(? IteratorValue(_next_))).
+              1. If _remaining_ is not +∞, then
+                1. Set _remaining_ to _remaining_ - 1.
+              1. Let _value_ be ? IteratorValue(_next_).
+              1. If _remaining_ is 0, then
+                1. Perform ? IteratorClose(_iterated_, NormalCompletion(*undefined*)).
+                1. Perform ? Yield(_value_).
+              1. Let _completion_ be Completion(Yield(_value_)).
               1. IfAbruptCloseIterator(_completion_, _iterated_).
           1. Return CreateIteratorFromClosure(_closure_, ~Iterator Helper~, %IteratorHelperPrototype%).
         </emu-alg>


### PR DESCRIPTION
Fixes #219. Draft until I do the same for async `take`.