### PR TITLE
fixes #229: flatMap supports returning both iterables and iterators

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -162,20 +162,24 @@ contributors: Gus Caplan
       <emu-alg>
         1. If _hint_ is not present, set _hint_ to ~sync~.
         1. If _iterator_ is either *undefined* or *null*, throw a *TypeError* exception.
+        1. Let _alreadyAsync_ be *false*.
         1. Let _method_ be *undefined*.
         1. If _hint_ is ~async~, then
           1. Set _method_ to ? GetV(_obj_, @@asyncIterator).
+          1. Set _alreadyAsync_ to *true*.
         1. If IsCallable(_method_) is *false*, then
           1. Set _method_ to ? GetV(_obj_, @@iterator).
+          1. Set _alreadyAsync_ to *false*.
         1. If IsCallable(_method_) is *false*, then
           1. Let _iterator_ be _obj_.
+          1. Set _alreadyAsync_ to *true*.
         1. Else,
           1. Let _iterator_ be ? Call(_method_, _obj_).
         1. If _iterator_ is not an Object, throw a *TypeError* exception.
         1. Let _nextMethod_ be ? Get(_iterator_, *"next"*).
         1. If IsCallable(_nextMethod_) is *false*, throw a *TypeError* exception.
         1. Let _iteratorRecord_ be the Iterator Record { [[Iterator]]: _iterator_, [[NextMethod]]: _nextMethod_, [[Done]]: *false* }.
-        1. If _hint_ is ~async~, then
+        1. If _hint_ is ~async~ and _alreadyAsync_ is *false*, then
           1. Return CreateAsyncFromSyncIterator(_iteratorRecord_).
         1. Return _iteratorRecord_.
       </emu-alg>

--- a/spec.html
+++ b/spec.html
@@ -244,7 +244,7 @@ contributors: Gus Caplan
         <emu-clause id="sec-iterator.from">
           <h1>Iterator.from ( _O_ )</h1>
           <emu-alg>
-            1. Let _iteratorRecord_ be GetIteratorFlattenable(_mapped_, ~sync~).
+            1. Let _iteratorRecord_ be ? GetIteratorFlattenable(_O_, ~sync~).
             1. Let _hasInstance_ be ? OrdinaryHasInstance(%Iterator%, _iteratorRecord_.[[Iterator]]).
             1. If _hasInstance_ is *true*, then
               1. Return _iteratorRecord_.[[Iterator]].
@@ -322,7 +322,7 @@ contributors: Gus Caplan
         <emu-clause id="sec-asynciterator.from">
           <h1>AsyncIterator.from ( _O_ )</h1>
           <emu-alg>
-            1. Let _iteratorRecord_ be GetIteratorFlattenable(_mapped_, ~sync~).
+            1. Let _iteratorRecord_ be ? GetIteratorFlattenable(_O_, ~sync~).
             1. Let _hasInstance_ be ? OrdinaryHasInstance(%AsyncIterator%, _iteratorRecord_.[[Iterator]]).
             1. If _hasInstance_ is *true*, then
               1. Return _iteratorRecord_.[[Iterator]].

--- a/spec.html
+++ b/spec.html
@@ -322,7 +322,7 @@ contributors: Gus Caplan
         <emu-clause id="sec-asynciterator.from">
           <h1>AsyncIterator.from ( _O_ )</h1>
           <emu-alg>
-            1. Let _iteratorRecord_ be ? GetIteratorFlattenable(_O_, ~sync~).
+            1. Let _iteratorRecord_ be ? GetIteratorFlattenable(_O_, ~async~).
             1. Let _hasInstance_ be ? OrdinaryHasInstance(%AsyncIterator%, _iteratorRecord_.[[Iterator]]).
             1. If _hasInstance_ is *true*, then
               1. Return _iteratorRecord_.[[Iterator]].

--- a/spec.html
+++ b/spec.html
@@ -323,6 +323,9 @@ contributors: Gus Caplan
           <h1>AsyncIterator.from ( _O_ )</h1>
           <emu-alg>
             1. Let _iteratorRecord_ be GetIteratorFlattenable(_mapped_, ~sync~).
+            1. Let _hasInstance_ be ? OrdinaryHasInstance(%AsyncIterator%, _iteratorRecord_.[[Iterator]]).
+            1. If _hasInstance_ is *true*, then
+              1. Return _iteratorRecord_.[[Iterator]].
             1. Let _wrapper_ be OrdinaryObjectCreate(%WrapForValidAsyncIteratorPrototype%, « [[AsyncIterated]] »).
             1. Set _wrapper_.[[AsyncIterated]] to _iteratorRecord_.
             1. Return _wrapper_.

--- a/spec.html
+++ b/spec.html
@@ -154,29 +154,27 @@ contributors: Gus Caplan
       <h1>
         GetIteratorFlattenable (
           _obj_: an ECMAScript language value,
-          optional _hint_: ~sync~ or ~async~,
+          _hint_: ~sync~ or ~async~,
         ): either a normal completion containing an Iterator Record or a throw completion
       </h1>
       <dl class="header">
       </dl>
       <emu-alg>
-        1. If _hint_ is not present, set _hint_ to ~sync~.
-        1. If _iterator_ is either *undefined* or *null*, throw a *TypeError* exception.
+        1. If _obj_ is not an Object, throw a *TypeError* exception.
         1. Let _alreadyAsync_ be *false*.
         1. Let _method_ be *undefined*.
         1. If _hint_ is ~async~, then
-          1. Set _method_ to ? GetV(_obj_, @@asyncIterator).
+          1. Set _method_ to ? Get(_obj_, @@asyncIterator).
           1. Set _alreadyAsync_ to *true*.
         1. If IsCallable(_method_) is *false*, then
-          1. Set _method_ to ? GetV(_obj_, @@iterator).
+          1. Set _method_ to ? Get(_obj_, @@iterator).
           1. Set _alreadyAsync_ to *false*.
         1. If IsCallable(_method_) is *false*, then
           1. Let _iterator_ be _obj_.
           1. Set _alreadyAsync_ to *true*.
         1. Else,
           1. Let _iterator_ be ? Call(_method_, _obj_).
-        1. If _iterator_ is not an Object, throw a *TypeError* exception.
-        1. Let _nextMethod_ be ? Get(_iterator_, *"next"*).
+        1. Let _nextMethod_ be ? GetV(_iterator_, *"next"*).
         1. If IsCallable(_nextMethod_) is *false*, throw a *TypeError* exception.
         1. Let _iteratorRecord_ be the Iterator Record { [[Iterator]]: _iterator_, [[NextMethod]]: _nextMethod_, [[Done]]: *false* }.
         1. If _hint_ is ~async~ and _alreadyAsync_ is *false*, then
@@ -246,14 +244,10 @@ contributors: Gus Caplan
         <emu-clause id="sec-iterator.from">
           <h1>Iterator.from ( _O_ )</h1>
           <emu-alg>
-            1. Let _usingIterator_ be ? GetMethod(_O_, @@iterator).
-            1. If _usingIterator_ is not *undefined*, then
-              1. Let _iteratorRecord_ be ? GetIterator(_O_, ~sync~, _usingIterator_).
-              1. If IsCallable(_iteratorRecord_.[[NextMethod]]) is *false*, throw a *TypeError* exception.
-              1. Let _hasInstance_ be ? OrdinaryHasInstance(%Iterator%, _iteratorRecord_.[[Iterator]]).
-              1. If _hasInstance_ is *true*, then
-                1. Return _iteratorRecord_.[[Iterator]].
-            1. Else, Let _iteratorRecord_ be ? GetIteratorDirect(_O_).
+            1. Let _iteratorRecord_ be GetIteratorFlattenable(_mapped_, ~sync~).
+            1. Let _hasInstance_ be ? OrdinaryHasInstance(%Iterator%, _iteratorRecord_.[[Iterator]]).
+            1. If _hasInstance_ is *true*, then
+              1. Return _iteratorRecord_.[[Iterator]].
             1. Let _wrapper_ be OrdinaryObjectCreate(%WrapForValidIteratorPrototype%, « [[Iterated]] »).
             1. Set _wrapper_.[[Iterated]] to _iteratorRecord_.
             1. Return _wrapper_.
@@ -328,21 +322,7 @@ contributors: Gus Caplan
         <emu-clause id="sec-asynciterator.from">
           <h1>AsyncIterator.from ( _O_ )</h1>
           <emu-alg>
-            1. Let _usingIterator_ be ? GetMethod(_O_, @@asyncIterator).
-            1. Let _iteratorRecord_ be *undefined*.
-            1. If _usingIterator_ is not *undefined*, then
-              1. Set _iteratorRecord_ to ? GetIterator(_O_, ~async~, _usingIterator_).
-              1. If IsCallable(_iteratorRecord_.[[NextMethod]]) is *false*, throw a *TypeError* exception.
-              1. Let _hasInstance_ be ? OrdinaryHasInstance(%AsyncIterator%, _iteratorRecord_.[[Iterator]]).
-              1. If _hasInstance_ is *true*, then
-                1. Return _iteratorRecord_.[[Iterator]].
-            1. If _iteratorRecord_ is *undefined*, then
-              1. Set _usingIterator_ to ? GetMethod(_O_, @@iterator).
-              1. If _usingIterator_ is not *undefined*, then
-                1. Let _syncIteratorRecord_ be ? GetIterator(_O_, ~sync~, _usingIterator_).
-                1. If IsCallable(_syncIteratorRecord_.[[NextMethod]]) is *false*, throw a *TypeError* exception.
-                1. Set _iteratorRecord_ to CreateAsyncFromSyncIterator(_syncIteratorRecord_).
-            1. If _iteratorRecord_ is *undefined*, set _iteratorRecord_ to ? GetIteratorDirect(_O_).
+            1. Let _iteratorRecord_ be GetIteratorFlattenable(_mapped_, ~sync~).
             1. Let _wrapper_ be OrdinaryObjectCreate(%WrapForValidAsyncIteratorPrototype%, « [[AsyncIterated]] »).
             1. Set _wrapper_.[[AsyncIterated]] to _iteratorRecord_.
             1. Return _wrapper_.

--- a/spec.html
+++ b/spec.html
@@ -149,6 +149,37 @@ contributors: Gus Caplan
         1. Return _iteratorRecord_.
       </emu-alg>
     </emu-clause>
+
+    <emu-clause id="sec-getiteratorflattenable" type="abstract operation">
+      <h1>
+        GetIteratorFlattenable (
+          _obj_: an ECMAScript language value,
+          optional _hint_: ~sync~ or ~async~,
+        ): either a normal completion containing an Iterator Record or a throw completion
+      </h1>
+      <dl class="header">
+      </dl>
+      <emu-alg>
+        1. If _hint_ is not present, set _hint_ to ~sync~.
+        1. If _iterator_ is either *undefined* or *null*, throw a *TypeError* exception.
+        1. Let _method_ be *undefined*.
+        1. If _hint_ is ~async~, then
+          1. Set _method_ to ? GetV(_obj_, @@asyncIterator).
+        1. If IsCallable(_method_) is *false*, then
+          1. Set _method_ to ? GetV(_obj_, @@iterator).
+        1. If IsCallable(_method_) is *false*, then
+          1. Let _iterator_ be _obj_.
+        1. Else,
+          1. Let _iterator_ be ? Call(_method_, _obj_).
+        1. If _iterator_ is not an Object, throw a *TypeError* exception.
+        1. Let _nextMethod_ be ? Get(_iterator_, *"next"*).
+        1. If IsCallable(_nextMethod_) is *false*, throw a *TypeError* exception.
+        1. Let _iteratorRecord_ be the Iterator Record { [[Iterator]]: _iterator_, [[NextMethod]]: _nextMethod_, [[Done]]: *false* }.
+        1. If _hint_ is ~async~, then
+          1. Return CreateAsyncFromSyncIterator(_iteratorRecord_).
+        1. Return _iteratorRecord_.
+      </emu-alg>
+    </emu-clause>
   </emu-clause>
 </emu-clause>
 
@@ -560,7 +591,7 @@ contributors: Gus Caplan
               1. Let _value_ be ? IteratorValue(_next_).
               1. Let _mapped_ be Completion(Call(_mapper_, *undefined*, « _value_ »)).
               1. IfAbruptCloseIterator(_mapped_, _iterated_).
-              1. Let _innerIterator_ be Completion(GetIterator(_mapped_, ~sync~)).
+              1. Let _innerIterator_ be Completion(GetIteratorFlattenable(_mapped_, ~sync~)).
               1. IfAbruptCloseIterator(_innerIterator_, _iterated_).
               1. Let _innerAlive_ be *true*.
               1. Repeat, while _innerAlive_ is *true*,
@@ -828,7 +859,7 @@ contributors: Gus Caplan
               1. IfAbruptCloseAsyncIterator(_mapped_, _iterated_).
               1. Set _mapped_ to Completion(Await(_mapped_)).
               1. IfAbruptCloseAsyncIterator(_mapped_, _iterated_).
-              1. Let _innerIterator_ be Completion(GetIterator(_mapped_, ~async~)).
+              1. Let _innerIterator_ be Completion(GetIteratorFlattenable(_mapped_, ~async~)).
               1. IfAbruptCloseAsyncIterator(_innerIterator_, _iterated_).
               1. Let _innerAlive_ be *true*.
               1. Repeat, while _innerAlive_ is *true*,


### PR DESCRIPTION
Fixes #229.

**update:** Now also fixes #237, aligning `flatMap` and `from`.

### `Iterator.prototype.flatMap` and `Iterator.from`:
* non-Object: throw
* has `Symbol.iterator`: call it, get sync iterator, iterate
* has callable `"next"`: assume sync iterator, iterate
* otherwise: throw

### `AsyncIterator.prototype.flatMap` and `AsyncIterator.from`:
* non-Object: throw
* has `Symbol.asyncIterator`: call it, get async iterator, async iterate
* has `Symbol.iterator`: call it, get sync iterator, lift to async iterator, async iterate
* has callable `"next"`: assume async iterator, async iterate
* otherwise: throw