### PR TITLE
fixes #230: don't await non-objects returned from functions passed to AsyncIterator HoFs

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -175,6 +175,20 @@ contributors: Gus Caplan
           1. Else if _value_ is a Completion Record, set _value_ to _value_.[[Value]].
         </emu-alg>
       </emu-clause>
+
+      <emu-clause id="sec-awaitnonprimitive" type="abstract operation">
+        <h1>
+          AwaitNonPrimitive (
+            _value_: an ECMAScript language value
+          ): either a normal completion containing an ECMAScript language value or a throw completion
+        </h1>
+        <dl class="header">
+        </dl>
+        <emu-alg>
+          1. If _value_ is an Object, return ? Await(_value_).
+          1. Else, return _value_.
+        </emu-alg>
+      </emu-clause>
     </emu-clause>
 
     <emu-clause id="sec-iterator-objects">
@@ -719,7 +733,7 @@ contributors: Gus Caplan
               1. Let _value_ be ? IteratorValue(_next_).
               1. Let _mapped_ be Completion(Call(_mapper_, *undefined*, « _value_ »)).
               1. IfAbruptCloseAsyncIterator(_mapped_, _iterated_).
-              1. Set _mapped_ to Completion(Await(_mapped_)).
+              1. Set _mapped_ to Completion(AwaitNonPrimitive(_mapped_)).
               1. IfAbruptCloseAsyncIterator(_mapped_, _iterated_).
               1. Let _completion_ be Completion(Yield(_mapped_)).
               1. IfAbruptCloseAsyncIterator(_completion_, _iterated_).
@@ -739,7 +753,7 @@ contributors: Gus Caplan
               1. Let _value_ be ? IteratorValue(_next_).
               1. Let _selected_ be Completion(Call(_filterer_, *undefined*, « _value_ »)).
               1. IfAbruptCloseAsyncIterator(_selected_, _iterated_).
-              1. Set _selected_ to Completion(Await(_selected_)).
+              1. Set _selected_ to Completion(AwaitNonPrimitive(_selected_)).
               1. IfAbruptCloseAsyncIterator(_selected_, _iterated_).
               1. If ToBoolean(_selected_) is *true*, then
                 1. Let _completion_ be Completion(Yield(_value_)).
@@ -826,7 +840,7 @@ contributors: Gus Caplan
               1. Let _value_ be ? IteratorValue(_next_).
               1. Let _mapped_ be Completion(Call(_mapper_, *undefined*, « _value_ »)).
               1. IfAbruptCloseAsyncIterator(_mapped_, _iterated_).
-              1. Set _mapped_ to Completion(Await(_mapped_)).
+              1. Set _mapped_ to Completion(AwaitNonPrimitive(_mapped_)).
               1. IfAbruptCloseAsyncIterator(_mapped_, _iterated_).
               1. Let _innerIterator_ be Completion(GetIterator(_mapped_, ~async~)).
               1. IfAbruptCloseAsyncIterator(_innerIterator_, _iterated_).
@@ -872,7 +886,7 @@ contributors: Gus Caplan
             1. Let _value_ be ? IteratorValue(_next_).
             1. Let _result_ be Completion(Call(_reducer_, *undefined*, « _accumulator_, _value_ »)).
             1. IfAbruptCloseAsyncIterator(_result_, _iterated_).
-            1. Set _result_ to Await(_result_).
+            1. Set _result_ to Completion(AwaitNonPrimitive(_result_)).
             1. IfAbruptCloseAsyncIterator(_result_, _iterated_).
             1. Set _accumulator_ to _result_.
         </emu-alg>
@@ -904,7 +918,7 @@ contributors: Gus Caplan
             1. Let _value_ be ? IteratorValue(_next_).
             1. Let _r_ be Completion(Call(_fn_, *undefined*, « _value_ »)).
             1. IfAbruptCloseAsyncIterator(_r_, _iterated_).
-            1. Set _r_ to Await(r).
+            1. Set _r_ to Completion(AwaitNonPrimitive(r)).
             1. IfAbruptCloseAsyncIterator(_r_, _iterated_).
         </emu-alg>
       </emu-clause>
@@ -921,7 +935,7 @@ contributors: Gus Caplan
             1. Let _value_ be ? IteratorValue(_next_).
             1. Let _result_ be Completion(Call(_fn_, *undefined*, « _value_ »)).
             1. IfAbruptCloseAsyncIterator(_result_, _iterated_).
-            1. Set _result_ to Await(_result_).
+            1. Set _result_ to Completion(AwaitNonPrimitive(_result_)).
             1. IfAbruptCloseAsyncIterator(_result_, _iterated_).
             1. If ToBoolean(_result_) is *true*, return ? AsyncIteratorClose(_iterated_, NormalCompletion(*true*)).
         </emu-alg>
@@ -939,7 +953,7 @@ contributors: Gus Caplan
             1. Let _value_ be ? IteratorValue(_next_).
             1. Let _result_ be Completion(Call(_fn_, *undefined*, « _value_ »)).
             1. IfAbruptCloseAsyncIterator(_result_, _iterated_).
-            1. Set _result_ to Await(_result_).
+            1. Set _result_ to Completion(AwaitNonPrimitive(_result_)).
             1. IfAbruptCloseAsyncIterator(_result_, _iterated_).
             1. If ToBoolean(_result_) is *false*, return ? AsyncIteratorClose(_iterated_, NormalCompletion(*false*)).
         </emu-alg>
@@ -957,7 +971,7 @@ contributors: Gus Caplan
             1. Let _value_ be ? IteratorValue(_next_).
             1. Let _result_ be Completion(Call(_fn_, *undefined*, « _value_ »)).
             1. IfAbruptCloseAsyncIterator(_result_, _iterated_).
-            1. Set _result_ to Await(_result_).
+            1. Set _result_ to Completion(AwaitNonPrimitive(_result_)).
             1. IfAbruptCloseAsyncIterator(_result_, _iterated_).
             1. If ToBoolean(_result_) is *true*, return ? AsyncIteratorClose(_iterated_, NormalCompletion(_value_)).
         </emu-alg>

--- a/spec.html
+++ b/spec.html
@@ -179,7 +179,7 @@ contributors: Gus Caplan
       <emu-clause id="sec-awaitnonprimitive" type="abstract operation">
         <h1>
           AwaitNonPrimitive (
-            _value_: an ECMAScript language value
+            _value_: an ECMAScript language value,
           ): either a normal completion containing an ECMAScript language value or a throw completion
         </h1>
         <dl class="header">


### PR DESCRIPTION
Fixes #230. This is only observable in the number of ticks taken to complete the method. It is always at least 1 because the async iteration protocol itself requires awaiting the IteratorResult object, so no Zalgo issues.