### PR TITLE
fix completion types in built-in async functions

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -202,7 +202,12 @@ contributors: Gus Caplan
       1. Push _calleeContext_ onto the execution context stack; _calleeContext_ is now the running execution context.
       1. Let _promiseCapability_ be ! NewPromiseCapability(%Promise%).
       1. Let _resultsClosure_ be a new Abstract Closure that captures _F_, _thisArgument_, and _argumentsList_ and performs the following steps when called:
-        1. Return the result of evaluating _F_ in a manner that conforms to the specification of _F_. _thisArgument_ is the *this* value, _argumentsList_ provides the named parameters, and the NewTarget value is *undefined*.
+        1. Let _result_ be the Completion Record that is the result of evaluating _F_ in a manner that conforms to the specification of _F_. _thisArgument_ is the *this* value, _argumentsList_ provides the named parameters, and the NewTarget value is *undefined*.
+        1. If _result_ is a normal completion, then
+          1. Return Completion Record { [[Type]]: ~return~, [[Value]]: _result_.[[Value]], [[Target]]: ~empty~ }.
+        1. Else,
+          1. Assert: _result_ is a throw completion.
+          1. Return Completion(_result_).
       1. Perform AsyncFunctionStart(_promiseCapability_, _resultsClosure_).
       1. Remove _calleeContext_ from the execution context stack and restore _callerContext_ as the running execution context.
       1. Return _promiseCapability_.

--- a/spec.html
+++ b/spec.html
@@ -202,12 +202,7 @@ contributors: Gus Caplan
       1. Push _calleeContext_ onto the execution context stack; _calleeContext_ is now the running execution context.
       1. Let _promiseCapability_ be ! NewPromiseCapability(%Promise%).
       1. Let _resultsClosure_ be a new Abstract Closure that captures _F_, _thisArgument_, and _argumentsList_ and performs the following steps when called:
-        1. Let _result_ be the Completion Record that is the result of evaluating _F_ in a manner that conforms to the specification of _F_. _thisArgument_ is the *this* value, _argumentsList_ provides the named parameters, and the NewTarget value is *undefined*.
-        1. If _result_ is a normal completion, then
-          1. Return Completion Record { [[Type]]: ~return~, [[Value]]: _result_.[[Value]], [[Target]]: ~empty~ }.
-        1. Else,
-          1. Assert: _result_ is a throw completion.
-          1. Return Completion(_result_).
+        1. Return the result of evaluating _F_ in a manner that conforms to the specification of _F_. _thisArgument_ is the *this* value, _argumentsList_ provides the named parameters, and the NewTarget value is *undefined*.
       1. Perform AsyncFunctionStart(_promiseCapability_, _resultsClosure_).
       1. Remove _calleeContext_ from the execution context stack and restore _callerContext_ as the running execution context.
       1. Return _promiseCapability_.
@@ -1139,6 +1134,8 @@ contributors: Gus Caplan
             1. <ins>Else,</ins>
               1. <ins>Assert: _asyncBody_ is an Abstract Closure with no parameters.</ins>
               1. <ins>Let _result_ be _asyncBody_().</ins>
+              1. <ins>If _result_ is a normal completion, then</ins>
+                1. <ins>Set _result_ to Completion Record { [[Type]]: ~return~, [[Value]]: _result_.[[Value]], [[Target]]: ~empty~ }.</ins>
             1. <del>Let _result_ be the result of evaluating _asyncBody_.</del>
             1. Assert: If we return here, the async function either threw an exception or performed an implicit or explicit return; all awaiting is done.
             1. Remove _asyncContext_ from the execution context stack and restore the execution context that is at the top of the execution context stack as the running execution context.


### PR DESCRIPTION
Missed a bit of wiring in https://github.com/tc39/proposal-iterator-helpers/pull/240.

Specifically, AsyncBlockStart is written to handle ES functions, meaning it expects return completions. Built-in functions don't need the return completion tracking at all, so they return normal completions containing values. We need to translate between the two.