### PR TITLE
throw in GetIteratorFlattenable when iterator is non-Object

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -174,7 +174,8 @@ contributors: Gus Caplan
           1. Set _alreadyAsync_ to *true*.
         1. Else,
           1. Let _iterator_ be ? Call(_method_, _obj_).
-        1. Let _nextMethod_ be ? GetV(_iterator_, *"next"*).
+        1. If _iterator_ is not an Object, throw a *TypeError* exception.
+        1. Let _nextMethod_ be ? Get(_iterator_, *"next"*).
         1. If IsCallable(_nextMethod_) is *false*, throw a *TypeError* exception.
         1. Let _iteratorRecord_ be the Iterator Record { [[Iterator]]: _iterator_, [[NextMethod]]: _nextMethod_, [[Done]]: *false* }.
         1. If _hint_ is ~async~ and _alreadyAsync_ is *false*, then


### PR DESCRIPTION
Fixes #247. I don't think it was a *problem* to `ToObject` the returned iterator, but this is more consistent with how iterators are treated elsewhere.