### PR TITLE
Normative: change Symbol.iterator fallback from callable check to undefined/null check

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -136,8 +136,8 @@ contributors: Gus Caplan
       </dl>
       <emu-alg>
         1. If _obj_ is not an Object, throw a *TypeError* exception.
-        1. Let _method_ be ? Get(_obj_, @@iterator).
-        1. If IsCallable(_method_) is *false*, then
+        1. Let _method_ be ? GetMethod(_obj_, @@iterator).
+        1. If _method_ is *undefined*, then
           1. Let _iterator_ be _obj_.
         1. Else,
           1. Let _iterator_ be ? Call(_method_, _obj_).


### PR DESCRIPTION
This better matches what we already do in `GetIterator` (used everywhere else we get an iterator from an iterable).  If `obj` has a `Symbol.iterator` property that is non-callable, it will now throw instead of falling back to treating `obj` as an iterator.