### PR TITLE
clarify that `from` is static

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,10 +296,9 @@ function* naturals() {
 naturals().find(v => v > 1); // 2
 ```
 
-### `.from(object)`
+### `Iterator.from(object)`
 
-`.from` takes an object as an argument. This method allows wrapping "iterator-like" objects with an
-iterator.
+`.from` is a _static_ method (unlike the others listed above) which takes an object as an argument. This method allows wrapping "iterator-like" objects with an iterator.
 
 Returns the object if it is already an iterator, returns a wrapping iterator if the passed object
 implements a callable @@iterator property.


### PR DESCRIPTION
Multiple people ([e.g.](https://github.com/domfarolino/observable/issues/28)) appear to have seen `from` in the readme and expected to find it next to the other methods in the spec, and been confused when it wasn't there. But since `from` is static, it's listed in a different section. This change hopefully will clarify that.