### PR TITLE
update generator state enum from "suspendedStart" to "suspended-start"

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -286,7 +286,7 @@ contributors: Gus Caplan
             1. Let _O_ be *this* value.
             1. Perform ? RequireInternalSlot(_O_, [[UnderlyingIterator]]).
             1. Assert: _O_ has a [[GeneratorState]] slot.
-            1. If _O_.[[GeneratorState]] is ~suspendedStart~, then
+            1. If _O_.[[GeneratorState]] is ~suspended-start~, then
               1. Set _O_.[[GeneratorState]] to ~completed~.
               1. NOTE: Once a generator enters the completed state it never leaves it and its associated execution context is never resumed. Any execution state associated with _O_ can be discarded at this point.
               1. Perform ? IteratorClose(_O_.[[UnderlyingIterator]], NormalCompletion(~unused~)).


### PR DESCRIPTION
New ecmarkup requires kebab case, and this matches the new enum spelling already used in 262.