### PR TITLE
Add missing quote for the initial value of the global object property

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -189,7 +189,7 @@ contributors: Gus Caplan
         <p>The <dfn>Iterator</dfn> constructor:</p>
         <ul>
           <li>is <dfn>%Iterator%</dfn>.</li>
-          <li>is the initial value of the *Iterator* property of the global object.</li>
+          <li>is the initial value of the *"Iterator"* property of the global object.</li>
           <li>is designed to be subclassable. It may be used as the value of an *extends* clause of a class definition.</li>
         </ul>
 


### PR DESCRIPTION
The spec uses double-quotation for the string property name when defining the initial value of the global object property.