### PR TITLE
Fix IteratorStep usage in Iterator.prototype.drop

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -432,8 +432,8 @@ contributors: Gus Caplan
             1. Repeat, while _remaining_ > 0,
               1. If _remaining_ is not +∞, then
                 1. Set _remaining_ to _remaining_ - 1.
-              1. Let _next_ be ? IteratorStep(_iterated_).
-              1. If _next_ is *false*, return *undefined*.
+              1. Let _result_ be ? IteratorStep(_iterated_).
+              1. If _result_ is ~done~, return *undefined*.
             1. Repeat,
               1. Let _value_ be ? IteratorStepValue(_iterated_).
               1. If _value_ is ~done~, return *undefined*.


### PR DESCRIPTION
Normal completion of https://tc39.es/ecma262/#sec-iteratorstep returns either `DONE` or iterator result object; I've validated this change against test262 coverage.